### PR TITLE
A complememtary relation between intervals based on delays between 2 'arbitrary' points

### DIFF
--- a/Packager/bin/tests_annotationdata_filter/test_delay.py
+++ b/Packager/bin/tests_annotationdata_filter/test_delay.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python2
+# vim: set fileencoding=UTF-8 ts=4 sw=4 expandtab:
+
+import unittest
+import os
+import sys
+from os.path import *
+import random
+
+SPPAS = dirname(dirname(dirname(dirname(abspath(__file__)))))
+sys.path.append(os.path.join(SPPAS, 'sppas', 'src'))
+
+from annotationdata.filter.delay_relations import Delay
+#import annotationdata.filter.delay_relations as delay_relations
+
+# some import to build intervals/Annotation
+from annotationdata.ptime.point import TimePoint
+from annotationdata.ptime.interval import TimeInterval
+from annotationdata.label.label import Label
+from annotationdata.annotation import Annotation
+
+
+class TestDelay(unittest.TestCase):
+    """ Test Delay class
+    """
+
+    #------------------------------------------------------------------------------------------
+    # an optional random.sample method
+    def _random_sample(self, list_, sample, testall=None):
+        if testall is None: # testall=None => use self._testall, but testall=False => avoid exhaustive test
+            testall = self._testall
+        if testall or sample > len(list_):   # the full list
+            return list_;
+        else:
+            return random.sample(list_, sample)
+
+    #------------------------------------------------------------------------------------------
+    def setUp(self):
+        pass
+
+    #------------------------------------------------------------------------------------------
+    def test__newSelf(self):
+        """
+        Test _newSelf() method : creation of an object of the same class
+        """
+        # a child class
+        class DChild(Delay):
+            pass
+
+        d1 = Delay(4.5, .3)
+        c1 = DChild(25.2, .5)
+        # d1 <op> c1 return a Delay
+        d1_mul_c1 = d1 * c1
+        t_d1_mul_c1 = type(d1_mul_c1)
+        self.assertEqual(t_d1_mul_c1, type(d1))
+        self.assertNotEqual(t_d1_mul_c1, type(c1))
+        # c1 <op> d1 return a DChild
+        c1_mul_d1 = c1 * d1
+        t_c1_mul_d1 = type(c1_mul_d1)
+        self.assertEqual(t_c1_mul_d1, type(c1))
+        self.assertNotEqual(t_c1_mul_d1, type(d1))
+        self.assertEqual(c1_mul_d1, d1_mul_c1)  # d1 * c1 == c1 * d1
+
+        # c1 <op> float return a DChild
+        c1_mul_1f = c1 * 1.
+        t_c1_mul_1f = type(c1_mul_1f)
+        self.assertEqual(t_c1_mul_d1, type(c1))
+        self.assertNotEqual(t_c1_mul_d1, type(d1))
+        self.assertEqual(c1_mul_1f, c1)  # c1 * 1. == c1
+        self.assertIs(c1_mul_1f, c1)  # c1 * d1 is c1
+        
+        
+        # another child class with a one parameter init
+        class DOtherChild(Delay):
+            def __init__(self, value):
+                Delay.__init__(self, value, 0.2)    # fixed margin
+
+        oc1 = DOtherChild(25.2)
+        # oc1 <op> d1 return a Delay (as we can't build a DOtherChild(value, margin))
+        #TODO: fix it in class Delay, i.e. use a (shalow) copy
+        oc1_mul_d1 = oc1 * d1
+        t_oc1_mul_d1 = type(oc1_mul_d1)
+        self.assertEqual(t_oc1_mul_d1, type(d1))
+        self.assertNotEqual(t_oc1_mul_d1, type(oc1))
+
+        # a grandson class
+        class DGrandson(DChild):
+            def __init__(self, value, margin=None, name="Jo"):
+                DChild.__init__(self, value, margin)    # fixed margin
+                DChild.name=name
+
+        gs1 = DGrandson(25.2, .4, "toto")
+        # gs1 <op> d1 return a DGrandson (as we can build a DGrandson(value, margin))
+        gs1_mul_d1 = gs1 * d1
+        t_gs1_mul_d1 = type(gs1_mul_d1)
+        self.assertEqual(t_gs1_mul_d1, type(gs1))
+        self.assertNotEqual(t_gs1_mul_d1, type(d1))
+
+# End TestDelay
+# ---------------------------------------------------------------------------
+
+if __name__ == '__main__':
+    suite = unittest.TestLoader().loadTestsFromTestCase(TestDelay)
+    unittest.TextTestRunner(verbosity=2).run(suite)
+

--- a/Packager/bin/tests_annotationdata_filter/test_delay_relations.py
+++ b/Packager/bin/tests_annotationdata_filter/test_delay_relations.py
@@ -9,7 +9,7 @@ from os.path import *
 SPPAS = dirname(dirname(dirname(dirname(abspath(__file__)))))
 sys.path.append(os.path.join(SPPAS, 'sppas', 'src'))
 
-from annotationdata.filter.delay_relations import IntervalsDelay
+from annotationdata.filter.delay_relations import IntervalsDelay, Delay
 #import annotationdata.filter.delay_relations as delay_relations
 
 # some import to build intervals/Annotation
@@ -49,6 +49,7 @@ class TestIntervalsDelay(unittest.TestCase):
 
     #------------------------------------------------------------------------------------------
     def setUp(self):
+        #Delay._NUMERIC = 'Decimal'  # change Delay numeric value
         self.p1 = TimePoint(1)
         self.p2 = TimePoint(2)
         self.p3 = TimePoint(3)

--- a/Packager/bin/tests_annotationdata_filter/test_delay_relations.py
+++ b/Packager/bin/tests_annotationdata_filter/test_delay_relations.py
@@ -1,0 +1,726 @@
+#!/usr/bin/env python2
+# vim: set fileencoding=UTF-8 ts=4 sw=4 expandtab:
+
+import unittest
+import os
+import sys
+from os.path import *
+
+SPPAS = dirname(dirname(dirname(dirname(abspath(__file__)))))
+sys.path.append(os.path.join(SPPAS, 'sppas', 'src'))
+
+from annotationdata.filter.delay_relations import IntervalsDelay
+#import annotationdata.filter.delay_relations as delay_relations
+
+# some import to build intervals/Annotation
+from annotationdata.ptime.point import TimePoint
+from annotationdata.ptime.interval import TimeInterval
+from annotationdata.label.label import Label
+from annotationdata.annotation import Annotation
+
+
+class TestIntervalsDelay(unittest.TestCase):
+    """ Test delays between 2 intervals/annotation
+    """
+
+    # some usefull values
+    PERCENTs={'start':0, 'end':1, 'middle':0.5, '25%':0.25, '75%':0.75, '50%':50./100, '100%':1.}
+    PERCENTsORDER=('start', '25%', 'middle', '75%', 'end')
+    PERCENTsSAME=[('middle', '50%'), ('end', '100%')]
+    MINs={'2':2, '0':0, '-infinity':None, '-2':-2, '1':1, 'one':1}
+    MINsORDER=('-infinity', '-2', '0', '1', '2')
+    MINsSAME=[('1', 'one')]
+    MAXs={'2':2, '0':0, '+infinity':None, '-2':-2, 'two':2}
+    MAXsORDER=('-2', '0', '2', '+infinity')
+    MAXsSAME=[('2', 'two')]
+    TIMEPOINTS=range(0,10)
+
+    #------------------------------------------------------------------------------------------
+    def validMinMaxDelay(cls, mindelay, maxdelay):
+        """
+        Check if the min/max is a valid combination,
+         i.e. min <= max, considering None as -/+infinity
+        """
+        if mindelay is None: # -infinity
+            return maxdelay is not None; # every value execept None
+        if maxdelay is None: # +infinity
+            return mindelay is not None; # every value execept None
+        return mindelay <= maxdelay # min < max
+
+    #------------------------------------------------------------------------------------------
+    def setUp(self):
+        self.p1 = TimePoint(1)
+        self.p2 = TimePoint(2)
+        self.p3 = TimePoint(3)
+        self.it = TimeInterval(self.p1, self.p2)
+        self.annotationI = Annotation(self.it, Label(" \t\t  être être   être  \n "))
+        self.annotationP= Annotation(self.p1, Label("mark"))
+        # Create some IntervalsDelay
+        self.intervalsDelays = {}
+        for xk, xpercent in self.PERCENTs.items():
+            for yk, ypercent in self.PERCENTs.items():
+                for mk, mindelay in self.MINs.items():
+                    for Mk, maxdelay in self.MAXs.items():
+                        if self.validMinMaxDelay(mindelay, maxdelay):
+                            self.intervalsDelays[(xk, yk, mk, Mk)] = IntervalsDelay(mindelay, maxdelay, xpercent, ypercent)
+                            
+
+    #------------------------------------------------------------------------------------------
+    def test___init__(self):
+        """
+        Test the IntervalsDelay constructor
+        """
+
+        # build a start_start IntervalsDelay's in various way
+        ssM1 = IntervalsDelay(0, 2, 0., 0.)
+        self.assertEqual(ssM1, self.intervalsDelays[('start', 'start', '0', '2')])
+        ssM2 = IntervalsDelay(mindelay=0, maxdelay=2, xpercent=0., ypercent=0.)
+        self.assertEqual(ssM1, ssM2)
+        ssM3 = IntervalsDelay(maxdelay=2, xpercent=0, ypercent=0)
+        self.assertEqual(ssM1, ssM3)
+        ssM4 = IntervalsDelay(0, 2, 0, 0)
+        self.assertEqual(ssM1, ssM4)
+
+        # build a start_end IntervalsDelay
+        seM1 = IntervalsDelay(0, 2, 0, 1)
+        self.assertEqual(seM1, self.intervalsDelays[('start', 'end', '0', '2')])
+        self.assertGreater(seM1,  ssM1) # start_end > start_start
+        
+        # build an end_start IntervalsDelay
+        esM1 = IntervalsDelay(0, 2, 1, 0)
+        self.assertEqual(esM1, self.intervalsDelays[('end', 'start', '0', '2')])
+        self.assertGreater(esM1,  seM1) # end_start > start_end
+
+        # build an end_end IntervalsDelay
+        eeM1 = IntervalsDelay(0, 2, 1, 1)
+        self.assertEqual(eeM1, self.intervalsDelays[('end', 'end', '0', '2')])
+        self.assertGreater(eeM1,  esM1) # end_end > end_start
+
+        # build some middle_middle IntervalsDelay (default values of xpercent/ypercent)
+        mmM1 = IntervalsDelay(0, 2)
+        self.assertEqual(mmM1, self.intervalsDelays[('middle', 'middle', '0', '2')])
+        mmM2 = IntervalsDelay(maxdelay=2)
+        self.assertEqual(mmM1, mmM2)
+        self.assertGreater(mmM1,  seM1) # middle_middle > start_end > start_start
+        self.assertLess(mmM1,  esM1) # middle_middle < end_start < end_end
+
+        # build some percent_percent IntervalsDelay
+        ppM1 = IntervalsDelay(0, 2, 0.25, 0.75)
+        self.assertEqual(ppM1, self.intervalsDelays[('25%', '75%', '0', '2')])
+        ppM2 = IntervalsDelay(mindelay=0, maxdelay=2, xpercent=0.25, ypercent=75./100) # /!\ 75/100=0 or 1 (int), 75./100 = 0.75
+        self.assertEqual(ppM1, ppM2)
+
+        # raise ValueError on invalid min/max delay
+        for mk, mindelay in self.MINs.items():
+            for Mk, maxdelay in self.MAXs.items():
+                if not self.validMinMaxDelay(mindelay, maxdelay): # use invald pairs
+                    for xk, xpercent in self.PERCENTs.items():
+                        for yk, ypercent in self.PERCENTs.items():
+                            with self.assertRaises(ValueError):
+                                IntervalsDelay(mindelay, maxdelay, xpercent, ypercent)
+
+    #------------------------------------------------------------------------------------------
+    def test___cmp__(self):
+        """
+        Test the IntervalsDelay comparator
+        """
+
+        # Compare the IntervalsDelay with same mindelay (but different keys)
+        checked = 0
+        for xk in self.PERCENTs.keys():
+            for yk in self.PERCENTs.keys():
+                for mk1, mk2 in self.MINsSAME:
+                    for Mk in self.MAXs.keys():
+                        if self.validMinMaxDelay(self.MINs[mk1], self.MAXs[Mk]):
+                            id1 = self.intervalsDelays[(xk, yk, mk1, Mk)]
+                            id2 = self.intervalsDelays[(xk, yk, mk2, Mk)]
+                            self.assertEqual(id1, id2, "NOT {} == {} : id1.cmp(id2) = {}".format(id1, id2, id1.__cmp__(id2)))
+                            checked+=1
+        self.assertGreater(checked, 0, "Any checks for same mindelay")
+        # Compare the IntervalsDelay with same maxdelay (but different keys)
+        for xk in self.PERCENTs.keys():
+            for yk in self.PERCENTs.keys():
+                for mk in self.MINs.keys():
+                    for Mk1, Mk2 in self.MAXsSAME:
+                        if self.validMinMaxDelay(self.MINs[mk], self.MAXs[Mk1]):
+                            id1=self.intervalsDelays[(xk, yk, mk, Mk1)]
+                            id2=self.intervalsDelays[(xk, yk, mk, Mk2)]
+                            self.assertEqual(id1, id2, "NOT {} == {} : id1.cmp(id2) = {}".format(id1, id2, id1.__cmp__(id2)))
+        # Compare the IntervalsDelay with same xpercent (but different keys)
+        for xk1, xk2 in self.PERCENTsSAME:
+            for yk in self.PERCENTs.keys():
+                for mk in self.MINs.keys():
+                    for Mk in self.MAXs.keys():
+                        if self.validMinMaxDelay(self.MINs[mk], self.MAXs[Mk]):
+                            id1=self.intervalsDelays[(xk1, yk, mk, Mk)]
+                            id2=self.intervalsDelays[(xk2, yk, mk, Mk)]
+                            self.assertEqual(id1, id2 , "NOT {} == {} : id1.cmp(id2) = {}".format(id1, id2, id1.__cmp__(id2)))
+        # Compare the IntervalsDelay with same ypercent (but different keys)
+        for xk in self.PERCENTs.keys():
+            for yk1, yk2 in self.PERCENTsSAME:
+                for mk in self.MINs.keys():
+                    for Mk in self.MAXs.keys():
+                        if self.validMinMaxDelay(self.MINs[mk], self.MAXs[Mk]):
+                            id1=self.intervalsDelays[(xk, yk1, mk, Mk)]
+                            id2=self.intervalsDelays[(xk, yk2, mk, Mk)]
+                            self.assertEqual(id1, id2, "NOT {} == {} : id1.cmp(id2) = {}".format(id1, id2, id1.__cmp__(id2)))
+        
+        # Check the order based on xpercent
+        for i in range(1,len(self.PERCENTsORDER)):
+            xk1, xk2 = self.PERCENTsORDER[i-1:i+1]
+            for yk in self.PERCENTs.keys():
+                for mk in self.MINs.keys():
+                    for Mk in self.MAXs.keys():
+                        if self.validMinMaxDelay(self.MINs[mk], self.MAXs[Mk]):
+                            id1 = self.intervalsDelays[(xk1, yk, mk, Mk)]
+                            id2 = self.intervalsDelays[(xk2, yk, mk, Mk)]
+                            self.assertLess(id1, id2, "NOT {} < {} : id1.cmp(id2) = {}".format(id1, id2, id1.__cmp__(id2)))
+        # Check the order based on ypercent
+        for xk in self.PERCENTs.keys():
+            for i in range(1,len(self.PERCENTsORDER)):
+                yk1, yk2 = self.PERCENTsORDER[i-1:i+1]
+                for mk in self.MINs.keys():
+                    for Mk in self.MAXs.keys():
+                        if self.validMinMaxDelay(self.MINs[mk], self.MAXs[Mk]):
+                            id1 = self.intervalsDelays[(xk, yk1, mk, Mk)]
+                            id2 = self.intervalsDelays[(xk, yk2, mk, Mk)]
+                            self.assertLess(id1, id2, "NOT {} < {} : id1.cmp(id2) = {}".format(id1, id2, id1.__cmp__(id2)))
+        # Check the order based on mindelay
+        for xk in self.PERCENTs.keys():
+            for yk in self.PERCENTs.keys():
+                for i in range(1,len(self.MINsORDER)):
+                    mk1, mk2 = self.MINsORDER[i-1:i+1];
+                    for Mk in self.MAXs.keys():
+                        try:
+                            id1=self.intervalsDelays[(xk, yk, mk1, Mk)]
+                            id2=self.intervalsDelays[(xk, yk, mk2, Mk)]
+                            self.assertLess(id1, id2 , "NOT {} < {} : id1.cmp(id2) = {}".format(id1, id2, id1.__cmp__(id2)))
+                        except KeyError:
+                            self.assertFalse( self.validMinMaxDelay(self.MINs[mk1], self.MAXs[Mk])
+                                and self.validMinMaxDelay(self.MINs[mk2], self.MAXs[Mk])
+                                )
+        # Check the order based on maxdelay
+        for xk in self.PERCENTs.keys():
+            for yk in self.PERCENTs.keys():
+                for mk in self.MINs.keys():
+                    for i in range(1,len(self.MAXsORDER)):
+                        Mk1, Mk2 = self.MAXsORDER[i-1:i+1];
+                        try:
+                            id1=self.intervalsDelays[(xk, yk, mk, Mk1)]
+                            id2=self.intervalsDelays[(xk, yk, mk, Mk2)]
+                            self.assertLess(id1, id2 , "NOT {} < {} : id1.cmp(id2) = {}".format(id1, id2, id1.__cmp__(id2)))
+                        except KeyError:# some invalid min/max combination, like max<min OR -infinity/+infinity
+                            self.assertFalse( self.validMinMaxDelay(self.MINs[mk], self.MAXs[Mk1])
+                                and self.validMinMaxDelay(self.MINs[mk], self.MAXs[Mk2])
+                                )
+
+    #------------------------------------------------------------------------------------------
+    def test_create(self):
+        """
+        Test the IntervalsDelay.create() method
+        """
+
+        # some easy case
+        ssM1 = IntervalsDelay.create('start_start_max', 2)
+        ssM2 = IntervalsDelay.create(start_start_max=2)
+        self.assertEquals(ssM1,ssM2)
+        self.assertEquals(ssM1,self.intervalsDelays[('start', 'start', '0', '2')])
+
+        # create with a couple of min/max values, i.e create(<xpt>_<ypt>, (min, max)), create(<xpt>_<ypt>=(min, max)), etc.
+        for xk in self.PERCENTs.keys():
+            for yk in self.PERCENTs.keys():
+                for mk in self.MINs.keys():
+                    mink=self.MINs[mk];
+                    for Mk in self.MAXs.keys():
+                        Maxk=self.MAXs[Mk];
+                        if self.validMinMaxDelay(mink, Maxk):
+                            # (a) create(<xpt>_<ypt>, (min, max))
+                            id1 = IntervalsDelay.create("{}_{}".format(xk, yk), (mink, Maxk))
+                            id2 = self.intervalsDelays[(xk, yk, mk, Mk)]
+                            self.assertEqual(id1, id2
+                                , "[{xk},{yk},{mk},{Mk}] (a) create('{xk}_{yk}', ({mink},{Maxk})) NOT {id1} == {id2}".format(**locals())
+                                )
+                            # (b) create(<xpt>_<ypt>=(min, max))
+                            kwargs={"{}_{}".format(xk, yk) : (mink, Maxk)}
+                            id1 = IntervalsDelay.create(**kwargs)
+                            self.assertEqual(id1, id2
+                                , "[{xk},{yk},{mk},{Mk}] (b) create({kwargs}) NOT {id1} == {id2}".format(**locals())
+                                )
+                            # (c) create(<xpt>_<ypt>, {mindelay=min, maxdelay=max})
+                            v={'mindelay':mink, 'maxdelay':Maxk}
+                            id1 = IntervalsDelay.create("{}_{}".format(xk, yk),v)
+                            self.assertEqual(id1, id2
+                                , "[{xk},{yk},{mk},{Mk}] (c) create('{xk}_{yk}',{v}) NOT {id1} == {id2}".format(**locals())
+                                )
+                            # (d) create('and', <xpt>_<ypt>, (min, max))
+                            id1 = IntervalsDelay.create('and', "{}_{}".format(xk, yk), (mink, Maxk))
+                            self.assertEqual(id1, id2
+                                , "[{xk},{yk},{mk},{Mk}] (d) create('and', '{xk}_{yk}', ({mink},{Maxk})) NOT {id1} == {id2}".format(**locals())
+                                )
+                            # (e) create('or', <xpt>_<ypt>, (min, max))
+                            id1 = IntervalsDelay.create('or', "{}_{}".format(xk, yk), (mink, Maxk))
+                            self.assertEqual(id1, id2
+                                , "[{xk},{yk},{mk},{Mk}] (e) create('or', '{xk}_{yk}', ({mink},{Maxk})) NOT {id1} == {id2}".format(**locals())
+                                )
+                            # (f) create('join', 'or', <xpt>_<ypt>, (min, max))
+                            id1 = IntervalsDelay.create('join','or', "{}_{}".format(xk, yk), (mink, Maxk))
+                            self.assertEqual(id1, id2
+                                , "[{xk},{yk},{mk},{Mk}] (f) create('join','or', '{xk}_{yk}', ({mink},{Maxk})) NOT {id1} == {id2}".format(**locals())
+                                )
+        
+        # create with min==max values, i.e create(<xpt>_<ypt>_eq, min), create(<xpt>_<ypt>=(min, min)), etc.
+        for xk in self.PERCENTs.keys():
+            for yk in self.PERCENTs.keys():
+                for mk in self.MINs.keys():
+                    mink=self.MINs[mk];
+                    if mink is None: continue; # skip -infinity/+infinity
+                    for Mk in self.MAXs.keys():
+                        Maxk=self.MAXs[Mk];
+                        if Maxk != mink: continue; # skip Max!=min
+                        # (a) create(<xpt>_<ypt>_eq, min)
+                        id1 = IntervalsDelay.create("{}_{}_eq".format(xk, yk), mink)
+                        id2 = self.intervalsDelays[(xk, yk, mk, Mk)]
+                        self.assertEqual(id1, id2
+                            , "[{xk},{yk},{mk},{Mk}] (a) create('{xk}_{yk}_eq', {mink}) NOT {id1} == {id2}".format(**locals())
+                            )
+                        # (b) create(<xpt>_<ypt>_eq, {delay=min})
+                        v={'delay':mink}
+                        id1 = IntervalsDelay.create("{}_{}_eq".format(xk, yk), v)
+                        self.assertEqual(id1, id2
+                            , "[{xk},{yk},{mk},{Mk}] (b) create('{xk}_{yk}_eq', {v}) NOT {id1} == {id2}".format(**locals())
+                            )
+                        # (c) create(<xpt>_<ypt>_eq=min)
+                        kwargs={"{}_{}_eq".format(xk, yk):mink}
+                        id1 = IntervalsDelay.create(**kwargs)
+                        self.assertEqual(id1, id2
+                            , "[{xk},{yk},{mk},{Mk}] (c) create({kwargs}) NOT {id1} == {id2}".format(**locals())
+                            )
+                        # (d) create(<xpt>_<ypt>_eq={delay=min})
+                        kwargs={"{}_{}_eq".format(xk, yk):{'delay':mink}}
+                        id1 = IntervalsDelay.create(**kwargs)
+                        self.assertEqual(id1, id2
+                            , "[{xk},{yk},{mk},{Mk}] (d) create({kwargs}) NOT {id1} == {id2}".format(**locals())
+                            )
+                        # (e) create(%_%, {xpercent, ypercent, delay})
+                        v={'xpercent':self.PERCENTs[xk], 'ypercent':self.PERCENTs[yk], 'delay':mink}
+                        id1 = IntervalsDelay.create('%_%_eq',v)
+                        self.assertEqual(id1, id2
+                            , "[{xk},{yk},{mk},{Mk}] (e) create('%_%', {v}) NOT {id1} == {id2}".format(**locals())
+                            )
+                        # (f) create(<xpt>_<ypt>, min) ('eq' is the default relation)
+                        id1 = IntervalsDelay.create("{}_{}".format(xk, yk), mink)
+                        self.assertEqual(id1, id2
+                            , "[{xk},{yk},{mk},{Mk}] (c) create('{xk}_{yk}', {mink}) NOT {id1} == {id2}".format(**locals())
+                            )
+                        # (g) create(%_%, {xpercent, ypercent, delay}) ('eq' is the default relation)
+                        v={'xpercent':self.PERCENTs[xk], 'ypercent':self.PERCENTs[yk], 'delay':Maxk}
+                        id1 = IntervalsDelay.create('%_%',v)
+                        self.assertEqual(id1, id2
+                            , "[{xk},{yk},{mk},{Mk}] (d) create('%_%', {v}) NOT {id1} == {id2}".format(**locals())
+                            )
+        # create with min values, i.e create(<xpt>_<ypt>_min, min) => Max = (min>=0 ? +infinity : 0)
+        for xk in self.PERCENTs.keys():
+            for yk in self.PERCENTs.keys():
+                for mk in self.MINs.keys():
+                    mink=self.MINs[mk];
+                    Mk = '0' if (mink is None or mink<0) else '+infinity' # Max = (min>=0 ? +infinity : 0)
+                    Maxk = self.MAXs[Mk];
+                    # (a) create(<xpt>_<ypt>_min, min)
+                    id1 = IntervalsDelay.create("{}_{}_min".format(xk, yk), mink)
+                    id2 = self.intervalsDelays[(xk, yk, mk, Mk)]
+                    self.assertEqual(id1, id2
+                        , "[{xk},{yk},{mk},{Mk}] (a) create('{xk}_{yk}_min', {mink}) NOT {id1} == {id2}".format(**locals())
+                        )
+                    # (b) create(<xpt>_<ypt>_min=min)
+                    kwargs={"{}_{}_min".format(xk, yk):mink}
+                    id1 = IntervalsDelay.create(**kwargs)
+                    self.assertEqual(id1, id2
+                        , "[{xk},{yk},{mk},{Mk}] (b) create({kwargs}) NOT {id1} == {id2}".format(**locals())
+                        )
+                    # (c) create(%_%_min, {xpercent, ypercent, mindelay})
+                    v={'xpercent':self.PERCENTs[xk], 'ypercent':self.PERCENTs[yk], 'mindelay':mink}
+                    id1 = IntervalsDelay.create('%_%_min',v)
+                    self.assertEqual(id1, id2
+                        , "[{xk},{yk},{mk},{Mk}] (b) create('%_%_min', {v}) NOT {id1} == {id2}".format(**locals())
+                        )
+        # create with Max values, i.e create(<xpt>_<ypt>_max, Max) => min = (Max>=0 ? 0 : -infinity)
+        for xk in self.PERCENTs.keys():
+            for yk in self.PERCENTs.keys():
+                for Mk in self.MAXs.keys():
+                    Maxk = self.MAXs[Mk];
+                    mk = '0' if (Maxk is None or Maxk>=0) else '-infinity' # min = (Max>=0 ? 0 : -infinity)
+                    mink=self.MINs[mk];
+                    # (a) create(<xpt>_<ypt>_max, max)
+                    id1 = IntervalsDelay.create("{}_{}_max".format(xk, yk), Maxk)
+                    id2 = self.intervalsDelays[(xk, yk, mk, Mk)]
+                    self.assertEqual(id1, id2
+                        , "[{xk},{yk},{mk},{Mk}] (a) create('{xk}_{yk}_max', {Maxk}) NOT {id1} == {id2}".format(**locals())
+                        )
+                    # (b) create(<xpt>_<ypt>_max=max)
+                    kwargs={"{}_{}_max".format(xk, yk):Maxk}
+                    id1 = IntervalsDelay.create(**kwargs)
+                    self.assertEqual(id1, id2
+                        , "[{xk},{yk},{mk},{Mk}] (b) create({kwargs}) NOT {id1} == {id2}".format(**locals())
+                        )
+                    # (d) create(%_%_max, {xpercent, ypercent, maxdelay})
+                    v={'xpercent':self.PERCENTs[xk], 'ypercent':self.PERCENTs[yk], 'maxdelay':Maxk}
+                    id1 = IntervalsDelay.create('%_%_max',v)
+                    self.assertEqual(id1, id2
+                        , "[{xk},{yk},{mk},{Mk}] (d) create('%_%_max', {v}) NOT {id1} == {id2}".format(**locals())
+                        )
+
+        # create joined IntervalsDelay
+        from annotationdata.filter.delay_relations import AndPredicates, OrPredicates
+        import random
+        for (xk1, yk1, mk1, Mk1) in random.sample(self.intervalsDelays.keys(),15): # get only 15 random values
+            min1 = self.MINs[mk1]; Max1 = self.MAXs[Mk1];
+            id1 = self.intervalsDelays[(xk1, yk1, mk1, Mk1)]
+            for (xk2, yk2, mk2, Mk2) in random.sample(self.intervalsDelays.keys(),15): # get only 15 random values
+
+                min2 = self.MINs[mk2]; Max2 = self.MAXs[Mk2];
+                id2 = self.intervalsDelays[(xk2, yk2, mk2, Mk2)]
+                idAnd = AndPredicates(id1, id2)
+                # (a) implicit AND
+                cargs=("{}_{}".format(xk1, yk1), (min1, Max1), "{}_{}".format(xk2, yk2), (min2, Max2));
+                ckwargs={};
+                idc = IntervalsDelay.create(*cargs, **ckwargs);
+                self.assertEqual(idc, idAnd
+                        , "[{xk1},{yk1},{mk1},{Mk1}][{xk2},{yk2},{mk2},{Mk2}] (a) create({cargs},{ckwargs}) NOT {idc} == {idAnd}".format(**locals())
+                        )
+                # (b) explicit AND : create("and", ...)
+                cargs=("AND", "{}_{}".format(xk1, yk1), (min1, Max1)) # mixing args and kwargs
+                ckwargs={"{}_{}".format(xk2, yk2):(min2, Max2)};
+                idc = IntervalsDelay.create(*cargs, **ckwargs);
+                self.assertEqual(idc, idAnd
+                        , "[{xk1},{yk1},{mk1},{Mk1}][{xk2},{yk2},{mk2},{Mk2}] (b) create({cargs},{ckwargs}) NOT {idc} == {idAnd}".format(**locals())
+                        )
+                # (c) explicit AND with 'join' : create(..., join="and", ...)
+                cargs=("{}_{}".format(xk1, yk1), (min1, Max1)) # mixing args and kwargs
+                ckwargs={'join':"AND", "{}_{}".format(xk2, yk2):(min2, Max2)};
+                idc = IntervalsDelay.create(*cargs, **ckwargs);
+                self.assertEqual(idc, idAnd
+                        , "[{xk1},{yk1},{mk1},{Mk1}][{xk2},{yk2},{mk2},{Mk2}] (c) create({cargs},{ckwargs}) NOT {idc} == {idAnd}".format(**locals())
+                        )
+                # (d) explicit AND with 'join' : create(..., join="and", ...)
+                cargs=("{}_{}".format(xk1, yk1), (min1, Max1), "{}_{}".format(xk2, yk2), (min2, Max2))
+                ckwargs={'join':"AND"};
+                idc = IntervalsDelay.create(*cargs, **ckwargs);
+                self.assertEqual(idc, idAnd
+                        , "[{xk1},{yk1},{mk1},{Mk1}][{xk2},{yk2},{mk2},{Mk2}] (d) create({cargs},{ckwargs}) NOT {idc} == {idAnd}".format(**locals())
+                        )
+                # (e) (explicit) OR (as 1st parameter)
+                idOr = OrPredicates(id1, id2)
+                cargs=("or", "{}_{}".format(xk1, yk1), (min1, Max1), "{}_{}".format(xk2, yk2), (min2, Max2)) 
+                ckwargs={};
+                try:
+                    idc = IntervalsDelay.create(*cargs, **ckwargs);
+                except:
+                    e = sys.exc_info()[0]
+                    print("Error with [{xk1},{yk1},{mk1},{Mk1}][{xk2},{yk2},{mk2},{Mk2}] create({cargs},{ckwargs}) : {e}".format(**locals()))
+                self.assertEqual(idc, idOr
+                    , "[{xk1},{yk1},{mk1},{Mk1}][{xk2},{yk2},{mk2},{Mk2}] (e) create({cargs},{ckwargs}) NOT {idc} == {idOr}".format(**locals())
+                    )
+                # (f) (explicit) OR with 'join' key
+                cargs=("join", "Or", "{}_{}".format(xk1, yk1), (min1, Max1), "{}_{}".format(xk2, yk2), (min2, Max2)) 
+                ckwargs={};
+                try:
+                    idc = IntervalsDelay.create(*cargs, **ckwargs);
+                except:
+                    e = sys.exc_info()[0]
+                    print("Error with [{xk1},{yk1},{mk1},{Mk1}][{xk2},{yk2},{mk2},{Mk2}] create({cargs},{ckwargs}) : {e}".format(**locals()))
+                self.assertEqual(idc, idOr
+                    , "[{xk1},{yk1},{mk1},{Mk1}][{xk2},{yk2},{mk2},{Mk2}] (f) create({cargs},{ckwargs}) NOT {idc} == {idOr}".format(**locals())
+                    )
+                # (g) (explicit) OR in kwargs
+                cargs=("{}_{}".format(xk1, yk1), (min1, Max1), "{}_{}".format(xk2, yk2), (min2, Max2)) 
+                ckwargs={'join':'OR'};
+                try:
+                    idc = IntervalsDelay.create(*cargs, **ckwargs);
+                except:
+                    e = sys.exc_info()[0]
+                    print("Error with [{xk1},{yk1},{mk1},{Mk1}][{xk2},{yk2},{mk2},{Mk2}] create({cargs},{ckwargs}) : {e}".format(**locals()))
+                self.assertEqual(idc, idOr
+                    , "[{xk1},{yk1},{mk1},{Mk1}][{xk2},{yk2},{mk2},{Mk2}] (g) create({cargs},{ckwargs}) NOT {idc} == {idOr}".format(**locals())
+                    )
+                # (h) Using kwargs for id1 AND id2 /!\ order can change
+                #import traceback
+                if (xk1, yk1) != (xk2, yk2): # (!) if (xk1, yk1) == (xk2, yk2), the "{}_{}" keys have the same value => the first is ignored
+                    idOrReverse = OrPredicates(id2, id1)
+                    cargs=("OR",) # /!\ the comma is important, else cargs=("OR") <=> cargs="OR"
+                    ckwargs={"{}_{}".format(xk1, yk1): (min1, Max1), "{}_{}".format(xk2, yk2):(min2, Max2)}; # /!\ not sur of the resulting order
+                    try:
+                        idc = IntervalsDelay.create(*cargs, **ckwargs);
+                        #print("With [{xk1},{yk1},{mk1},{Mk1}][{xk2},{yk2},{mk2},{Mk2}]\n\tidc={idc}\n\tidOr={idOr}\n\tidOrReverse={idOrReverse}".format(**locals()))
+                        self.assertTrue( (idc == idOr) or (idc == idOrReverse) 
+                            , "[{xk1},{yk1},{mk1},{Mk1}][{xk2},{yk2},{mk2},{Mk2}] (h) create({cargs},{ckwargs}) NOT {idc} == {idOr} (or {idOrReverse})".format(**locals())
+                            )
+                    except:
+                        e = sys.exc_info()[0]
+                        print("Error with [{xk1},{yk1},{mk1},{Mk1}][{xk2},{yk2},{mk2},{Mk2}] create({cargs},{ckwargs}) : {e}'".format(**locals()))
+                        #traceback.print_exception(*sys.exc_info())
+
+    #------------------------------------------------------------------------------------------
+    def test___call__(self):
+        import random
+        # Create some TimePoint, TimeInterval and Annotation
+        # - create the TimePoints:  self.timePoints[i] = TimePoint(i) (0<=i<=9) (=> 10)
+        self.timePoints = {i:TimePoint(i) for i in self.TIMEPOINTS }
+        # - create the TimeInterval:  [timePoints[i], timePoints[j]] 0<=i<j<=9 (=> 45)
+        self.timeIntervals = dict();
+        for i in self.timePoints.keys():
+            for j in self.timePoints.keys():
+                if i<j:
+                    self.timeIntervals[(i,j)] = TimeInterval(self.timePoints[i], self.timePoints[j])
+        # - create the point annotations:
+        self.pointAnnotations = {i:Annotation(self.timePoints[i], Label("point at {:.3f}s".format(i))) for i in self.timePoints.keys()}
+        # - create the intervals annotations:
+        self.intervalAnnotations = {(i,j):Annotation(self.timeIntervals[(i,j)], Label("interval [{:.3f}, {:.3f}]s".format(i,j))) for (i,j) in self.timeIntervals.keys()}
+        
+        # check the start_start_max predicate
+        nbAsserts=0
+        for Mk in self.MAXsORDER:
+            Maxd = self.MAXs[Mk]
+            #if Maxd<0: continue; # TODO
+            for mk in self.MINsORDER:
+                mind = self.MINs[mk]
+                if Maxd is None and mind is None: break; # => invalid interval
+                if mind>Maxd: break; # mind > Maxd => invalid interval
+                for xk in ['start']:
+                    yk=xk; # same reference point
+                    idc = self.intervalsDelays[(xk, yk, mk, Mk)]
+                    # compare 2 point annotations
+                    for i in self.pointAnnotations.keys():
+                        for j in self.pointAnnotations.keys():
+                            pai = self.pointAnnotations[i]
+                            paj = self.pointAnnotations[j]
+                            pred = idc(pai, paj)
+                            if (j-i) > Maxd:
+                                self.assertFalse(pred
+                                    , "IntervalsDelays[{xk},{yk},{mk},{Mk}]({pai}, {paj}) isn't false when ({j}-{i}) > {Maxd} (pred={pred}; ped.delay={pred_delay})".format(pred_delay=pred.delay if (hasattr(pred,'delay')) else None,**locals())
+                                    ); nbAsserts+=1
+                            elif (mind is None or mind<=(j-i)):
+                                self.assertTrue(pred
+                                    , "IntervalsDelays[{xk},{yk},{mk},{Mk}]({pai}, {paj}) isn't true when {mind} <= ({j}-{i}) < {Maxd} (pred={pred}; ped.delay={pred_delay})".format(pred_delay=pred.delay if (hasattr(pred,'delay')) else None,**locals())
+                                    ); nbAsserts+=1
+                            else: # (j-i) < min
+                                self.assertFalse(pred
+                                    , "IntervalsDelays[{xk},{yk},{mk},{Mk}]({pai}, {paj}) isn't false when ({j}-{i}) < {mind} (pred={pred}; ped.delay={pred_delay})".format(pred_delay=pred.delay if (hasattr(pred,'delay')) else None,**locals())
+                                    ); nbAsserts+=1
+                    # compare a point and an interval annotations
+                    for start1 in self.pointAnnotations.keys():
+                        for (start2, end2) in random.sample(self.intervalAnnotations.keys(),15):
+                            a1 = self.pointAnnotations[start1]
+                            a2 = self.intervalAnnotations[(start2, end2)]
+                            pred = idc(a1, a2)
+                            if (start2-start1) > Maxd:
+                                self.assertFalse(pred
+                                    , "IntervalsDelays[{xk},{yk},{mk},{Mk}]({pai}, {paj}) isn't false when ({start2}-{start1}) > {Maxd} (pred={pred}; ped.delay={pred_delay})".format(pred_delay=pred.delay if (hasattr(pred,'delay')) else None,**locals())
+                                    ); nbAsserts+=1
+                            elif (mind is None or mind<=(start2-start1)):
+                                self.assertTrue(pred
+                                    , "IntervalsDelays[{xk},{yk},{mk},{Mk}]({pai}, {paj}) isn't true when {mind} <= ({start2}-{start1}) < {Maxd} (pred={pred}; ped.delay={pred_delay})".format(pred_delay=pred.delay if (hasattr(pred,'delay')) else None,**locals())
+                                    ); nbAsserts+=1
+                            else: # (start2-start1) < min
+                                self.assertFalse(pred
+                                    , "IntervalsDelays[{xk},{yk},{mk},{Mk}]({pai}, {paj}) isn't false when ({start2}-{start1}) < {mind} (pred={pred}; ped.delay={pred_delay})".format(pred_delay=pred.delay if (hasattr(pred,'delay')) else None,**locals())
+                                    ); nbAsserts+=1
+                    # compare 2 interval annotations
+                    for (start1, end1) in random.sample(self.intervalAnnotations.keys(),15):
+                        for (start2, end2) in random.sample(self.intervalAnnotations.keys(),15):
+                            a1 = self.intervalAnnotations[(start1, end1)]
+                            a2 = self.intervalAnnotations[(start2, end2)]
+                            pred = idc(a1, a2)
+                            if (start2-start1) > Maxd:
+                                self.assertFalse(pred
+                                    , "IntervalsDelays[{xk},{yk},{mk},{Mk}]({pai}, {paj}) isn't false when ({start2}-{start1}) > {Maxd} (pred={pred}; ped.delay={pred_delay})".format(pred_delay=pred.delay if (hasattr(pred,'delay')) else None,**locals())
+                                    ); nbAsserts+=1
+                            elif (mind is None or mind<=(start2-start1)):
+                                self.assertTrue(pred
+                                    , "IntervalsDelays[{xk},{yk},{mk},{Mk}]({pai}, {paj}) isn't true when {mind} <= ({start2}-{start1}) < {Maxd} (pred={pred}; ped.delay={pred_delay})".format(pred_delay=pred.delay if (hasattr(pred,'delay')) else None,**locals())
+                                    ); nbAsserts+=1
+                            else: # (start2-start1) < min
+                                self.assertFalse(pred
+                                    , "IntervalsDelays[{xk},{yk},{mk},{Mk}]({pai}, {paj}) isn't false when ({start2}-{start1}) < {mind} (pred={pred}; ped.delay={pred_delay})".format(pred_delay=pred.delay if (hasattr(pred,'delay')) else None,**locals())
+                                    ); nbAsserts+=1
+        if nbAsserts<=0: raise Warning("Any assertion in the test loop");
+
+        # check the start_end predicates
+        nbAsserts=0
+        for Mk in self.MAXsORDER:
+            Maxd = self.MAXs[Mk]
+            #if Maxd<0: continue; # TODO
+            for mk in self.MINsORDER:
+                mind = self.MINs[mk]
+                if Maxd is None and mind is None: break; # => invalid interval
+                if mind>Maxd: break; # mind > Maxd => invalid interval
+                for (xk, yk) in [('start','end'), ('start', '100%')]:
+                    idc = self.intervalsDelays[(xk, yk, mk, Mk)]
+                    # compare 2 interval annotations
+                    for (start1, end1) in random.sample(self.intervalAnnotations.keys(),15):
+                        for (start2, end2) in random.sample(self.intervalAnnotations.keys(),15):
+                            a1 = self.intervalAnnotations[(start1, end1)]
+                            a2 = self.intervalAnnotations[(start2, end2)]
+                            pred = idc(a1, a2)
+                            delay = (end2-start1)
+                            if delay > Maxd:
+                                self.assertFalse(pred
+                                    , "IntervalsDelays[{xk},{yk},{mk},{Mk}]({pai}, {paj}) isn't false when ({delay} > {Maxd}) (pred={pred}; ped.delay={pred_delay})".format(pred_delay=pred.delay if (hasattr(pred,'delay')) else None,**locals())
+                                    ); nbAsserts+=1
+                            elif (mind is None or mind<=delay):
+                                self.assertTrue(pred
+                                    , "IntervalsDelays[{xk},{yk},{mk},{Mk}]({pai}, {paj}) isn't true when ({mind} <= {delay}) < {Maxd}) (pred={pred}; ped.delay={pred_delay})".format(pred_delay=pred.delay if (hasattr(pred,'delay')) else None,**locals())
+                                    ); nbAsserts+=1
+                            else: # (start2-start1) < min
+                                self.assertFalse(pred
+                                    , "IntervalsDelays[{xk},{yk},{mk},{Mk}]({pai}, {paj}) isn't false when ({delay} < {mind}) (pred={pred}; ped.delay={pred_delay})".format(pred_delay=pred.delay if (hasattr(pred,'delay')) else None,**locals())
+                                    ); nbAsserts+=1
+        if nbAsserts<=0: raise Warning("Any assertion in the test loop");
+
+        # check the end_start predicates
+        nbAsserts=0
+        for Mk in self.MAXsORDER:
+            Maxd = self.MAXs[Mk]
+            #if Maxd<0: continue; # TODO
+            for mk in self.MINsORDER:
+                mind = self.MINs[mk]
+                if Maxd is None and mind is None: break; # => invalid interval
+                if mind>Maxd: break; # mind > Maxd => invalid interval
+                for (xk, yk) in [('end','start'), ('100%', 'start')]:
+                    idc = self.intervalsDelays[(xk, yk, mk, Mk)]
+                    # compare 2 interval annotations
+                    for (start1, end1) in random.sample(self.intervalAnnotations.keys(),15):
+                        for (start2, end2) in random.sample(self.intervalAnnotations.keys(),15):
+                            a1 = self.intervalAnnotations[(start1, end1)]
+                            a2 = self.intervalAnnotations[(start2, end2)]
+                            pred = idc(a1, a2)
+                            delay = (start2-end1)
+                            if delay > Maxd:
+                                self.assertFalse(pred
+                                    , "IntervalsDelays[{xk},{yk},{mk},{Mk}]({pai}, {paj}) isn't false when ({delay} > {Maxd}) (pred={pred}; ped.delay={pred_delay})".format(pred_delay=pred.delay if (hasattr(pred,'delay')) else None,**locals())
+                                    ); nbAsserts+=1
+                            elif (mind is None or mind<=delay):
+                                self.assertTrue(pred
+                                    , "IntervalsDelays[{xk},{yk},{mk},{Mk}]({pai}, {paj}) isn't true when ({mind} <= {delay}) < {Maxd}) (pred={pred}; ped.delay={pred_delay})".format(pred_delay=pred.delay if (hasattr(pred,'delay')) else None,**locals())
+                                    ); nbAsserts+=1
+                            else: # (start2-start1) < min
+                                self.assertFalse(pred
+                                    , "IntervalsDelays[{xk},{yk},{mk},{Mk}]({pai}, {paj}) isn't false when ({delay} < {mind}) (pred={pred}; ped.delay={pred_delay})".format(pred_delay=pred.delay if (hasattr(pred,'delay')) else None,**locals())
+                                    ); nbAsserts+=1
+        if nbAsserts<=0: raise Warning("Any assertion in the test loop");
+
+        # check some percent/percent predicates
+        nbAsserts=0
+        for Mk in self.MAXsORDER:
+            Maxd = self.MAXs[Mk]
+            #if Maxd<0: continue; # TODO
+            for mk in self.MINsORDER:
+                mind = self.MINs[mk]
+                if Maxd is None and mind is None: break; # => invalid interval
+                if mind>Maxd: break; # mind > Maxd => invalid interval
+                for (xk, yk) in [('middle','25%'), ('50%', '75%')]:
+                    idc = self.intervalsDelays[(xk, yk, mk, Mk)]
+                    # compare 2 interval annotations
+                    for (start1, end1) in random.sample(self.intervalAnnotations.keys(),15):
+                        for (start2, end2) in random.sample(self.intervalAnnotations.keys(),15):
+                            a1 = self.intervalAnnotations[(start1, end1)]
+                            a2 = self.intervalAnnotations[(start2, end2)]
+                            pred = idc(a1, a2)
+                            delay = ( ( start2 + self.PERCENTs[yk] * (end2-start2))
+                                    - ( start1 + self.PERCENTs[xk] * (end1-start1))
+                                    )
+                            if delay > Maxd:
+                                self.assertFalse(pred
+                                    , "IntervalsDelays[{xk},{yk},{mk},{Mk}]({pai}, {paj}) isn't false when ({delay} > {Maxd}) (pred={pred}; ped.delay={pred_delay})".format(pred_delay=pred.delay if (hasattr(pred,'delay')) else None,**locals())
+                                    ); nbAsserts+=1
+                            elif (mind is None or mind<=delay):
+                                # pred is a CheckedIntervalsDelay
+                                self.assertTrue(pred
+                                    , "IntervalsDelays[{xk},{yk},{mk},{Mk}]({pai}, {paj}) isn't true when ({mind} <= {delay}) < {Maxd}) (pred={pred}; ped.delay={pred_delay})".format(pred_delay=pred.delay if (hasattr(pred,'delay')) else None,**locals())
+                                    ); nbAsserts+=1
+                                # pred.delay == delay
+                                self.assertEqual(delay, pred.delay
+                                    , "IntervalsDelays[{xk},{yk},{mk},{Mk}]({pai}, {paj}) {delay}) != pred.delay={pred_delay})".format(pred_delay=pred.delay if (hasattr(pred,'delay')) else None,**locals())
+                                    ); nbAsserts+=1
+                            else: # (start2-start1) < min
+                                self.assertFalse(pred
+                                    , "IntervalsDelays[{xk},{yk},{mk},{Mk}]({pai}, {paj}) isn't false when ({delay} < {mind}) (pred={pred}; ped.delay={pred_delay})".format(pred_delay=pred.delay if (hasattr(pred,'delay')) else None,**locals())
+                                    ); nbAsserts+=1
+        if nbAsserts<=0: raise Warning("Any assertion in the test loop");
+        
+        # check some AND/OR predicate
+        from annotationdata.filter.delay_relations import AndPredicates, OrPredicates
+        nbAsserts=0
+        for (xk1, yk1, mk1, Mk1) in random.sample(self.intervalsDelays.keys(),10): # get only 10 random values
+            min1 = self.MINs[mk1]; Max1 = self.MAXs[Mk1];
+            id1 = self.intervalsDelays[(xk1, yk1, mk1, Mk1)]
+            #for (xk2, yk2, mk2, Mk2) in random.sample([k for k in self.intervalsDelays.keys() if (k[0], k[1])==(xk1, yk1)],10): # get only 10 random values, with same xk, yk
+            for (xk2, yk2, mk2, Mk2) in random.sample(self.intervalsDelays.keys(),10): # get only 10 random values
+                min2 = self.MINs[mk2]; Max2 = self.MAXs[Mk2];
+                id2 = self.intervalsDelays[(xk2, yk2, mk2, Mk2)]
+                idAnd = AndPredicates(id1, id2)
+                idOr = OrPredicates(id1, id2)
+                # compare 2 interval annotations
+                for (start1, end1) in random.sample(self.intervalAnnotations.keys(),10):
+                    for (start2, end2) in random.sample(self.intervalAnnotations.keys(),10):
+                        a1 = self.intervalAnnotations[(start1, end1)]
+                        a2 = self.intervalAnnotations[(start2, end2)]
+                        # compute delay and value
+                        # - for the first IntervalsDelay
+                        delay1 = ( ( start2 + self.PERCENTs[yk1] * (end2-start2))
+                                - ( start1 + self.PERCENTs[xk1] * (end1-start1))
+                                )
+                        v1 = (Max1 is None or (delay1<=Max1)) and (min1 is None or (min1<=delay1))
+                        # - for the second IntervalsDelay
+                        delay2 = ( ( start2 + self.PERCENTs[yk2] * (end2-start2))
+                                - ( start1 + self.PERCENTs[xk2] * (end1-start1))
+                                )
+                        v2 = (Max2 is None or (delay2<=Max2)) and (min2 is None or (min2<=delay2))
+                        # compute each predicate (for error message)
+                        pred1 = id1(a1, a2);
+                        pred2 = id2(a1, a2)
+                        # (a) AND
+                        predAnd = idAnd(a1, a2)
+                        if (v1 and v2):
+                            self.assertTrue(predAnd
+                                , "AndPredicates[[{xk1},{yk1},{mk1},{Mk1}],[{xk2},{yk2},{mk2},{Mk2}]]({a1}, {a2}) isn't true predAnd={predAnd} (delay1={delay1}, pred1={pred1}, delay2={delay2}, pred2={pred2}, v1={v1}, v2={v2}))".format(**locals())
+                                ); nbAsserts+=1
+                            # check the AND predicate return the list of predicate
+                            self.assertEqual(predAnd, [pred1, pred2]
+                                , "AndPredicates[[{xk1},{yk1},{mk1},{Mk1}],[{xk2},{yk2},{mk2},{Mk2}]]({a1}, {a2}) isn't equals to list of predicate predAnd={predAnd} (delay1={delay1}, pred1={pred1}, delay2={delay2}, pred2={pred2}, v1={v1}, v2={v2}))".format(**locals())
+                                )
+                        else:
+                            self.assertFalse(predAnd
+                                , "AndPredicates[[{xk1},{yk1},{mk1},{Mk1}],[{xk2},{yk2},{mk2},{Mk2}]]({a1}, {a2}) isn't false predAnd={predAnd} (delay1={delay1}, pred1={pred1}, delay2={delay2}, pred2={pred2}, v1={v1}, v2={v2}))".format(**locals())
+                                ); nbAsserts+=1
+                        # (b) OR
+                        predOr = idOr(a1, a2)
+                        if (v1 or v2):
+                            self.assertTrue(predOr
+                                , "OrPredicates[[{xk1},{yk1},{mk1},{Mk1}],[{xk2},{yk2},{mk2},{Mk2}]]({a1}, {a2}) isn't true predOr={predOr} (delay1={delay1}, pred1={pred1}, delay2={delay2}, pred2={pred2}, v1={v1}, v2={v2}))".format(**locals())
+                                ); nbAsserts+=1
+                            # check the OR predicate return the 1st true value
+                            if v1:
+                                self.assertEqual(predOr, pred1
+                                    , "OrPredicates[[{xk1},{yk1},{mk1},{Mk1}],[{xk2},{yk2},{mk2},{Mk2}]]({a1}, {a2}) string isn't equals to first true predicate predOr={predOr} (delay1={delay1}, pred1={pred1}, delay2={delay2}, pred2={pred2}, v1={v1}, v2={v2}))".format(**locals())
+
+                                    )
+                            else:
+                                self.assertEqual(predOr, pred2
+                                    , "OrPredicates[[{xk1},{yk1},{mk1},{Mk1}],[{xk2},{yk2},{mk2},{Mk2}]]({a1}, {a2}) string isn't equals to first true predicate predOr={predOr} (delay1={delay1}, pred1={pred1}, delay2={delay2}, pred2={pred2}, v1={v1}, v2={v2}))".format(**locals())
+
+                                    )
+                        else:
+                            self.assertFalse(predOr
+                                , "OrPredicates[[{xk1},{yk1},{mk1},{Mk1}],[{xk2},{yk2},{mk2},{Mk2}]]({a1}, {a2}) isn't false predOr={predOr} (delay1={delay1}, pred1={pred1}, delay2={delay2}, pred2={pred2}, v1={v1}, v2={v2}))".format(**locals())
+                                ); nbAsserts+=1
+        if nbAsserts<=0: raise Warning("Any assertion in the test loop");
+
+            
+
+# End TestIntervalsDelay
+# ---------------------------------------------------------------------------
+
+if __name__ == '__main__':
+    suite = unittest.TestLoader().loadTestsFromTestCase(TestIntervalsDelay)
+    unittest.TextTestRunner(verbosity=2).run(suite)
+

--- a/Packager/bin/tests_annotationdata_filter/test_delay_relations.py
+++ b/Packager/bin/tests_annotationdata_filter/test_delay_relations.py
@@ -716,7 +716,55 @@ class TestIntervalsDelay(unittest.TestCase):
                                 ); nbAsserts+=1
         if nbAsserts<=0: raise Warning("Any assertion in the test loop");
 
-            
+    #------------------------------------------------------------------------------------------
+    def test_andorOperators(self):
+        from annotationdata.filter.delay_relations import AndPredicates, OrPredicates
+        import random
+        nbAsserts=0
+        # combination of 2 IntervalsDelays
+        for id1 in random.sample(self.intervalsDelays.values(),10): # get only 10 random values
+            for id2 in random.sample(self.intervalsDelays.values(),10): # get only 10 random values
+                # (a) & operator
+                idAnd = AndPredicates(id1, id2)
+                idAndOp = id1 & id2
+                self.assertEquals(idAnd, idAndOp
+                    , "(id1 & id2)={idAndOp} isn't equals to AndPredicates(id1, id2)={idAnd}".format(**locals())
+                    ); nbAsserts+=1
+                # (b) | operator
+                idOr = OrPredicates(id1, id2)
+                idOrOp = id1 | id2
+                self.assertEquals(idOr, idOrOp
+                    , "(id1 | id2)={idOrOp} isn't equals to OrPredicates(id1, id2)={idOr}".format(**locals())
+                    ); nbAsserts+=1
+                # add a 3 value
+                for id3 in random.sample(self.intervalsDelays.values(),10): # get only 10 random values
+                    # (a) & operator
+                    idAnd2 = AndPredicates(idAnd, id3)
+                    idAndOp2 = id1 & id2 & id3
+                    self.assertEquals(idAnd2, idAndOp2
+                        , "(id1 & id2 & id3)={idAndOp2} isn't equals to AndPredicates(AndPredicates(id1, id2), id3)={idAnd2}".format(**locals())
+                        ); nbAsserts+=1
+                    # with IntervalDelay before
+                    idAnd3 = AndPredicates(id3, idAnd)
+                    idAndOp3 = id3 & (id1 & id2)
+                    self.assertEquals(idAnd3, idAndOp3
+                        , "(id3 & (id1 & id2))={idAndOp3} isn't equals to AndPredicates(id3, AndPredicates(id1, id2))={idAnd3}".format(**locals())
+                        ); nbAsserts+=1
+                    # (b) | operator
+                    idOr2 = OrPredicates(idOr, id3)
+                    idOrOp2 = id1 | id2 | id3
+                    self.assertEquals(idOr2, idOrOp2
+                        , "(id1 | id2 | id3)={idOrOp2} isn't equals to OrPredicates(OrPredicates(id1, id2), id3)={idOr2}".format(**locals())
+                        ); nbAsserts+=1
+                    # with IntervalDelay before
+                    idOr3 = OrPredicates(id3, idOr)
+                    idOrOp3 = id3 | (id1 | id2)
+                    self.assertEquals(idOr3, idOrOp3
+                        , "(id3 | (id1 | id2))={idOrOp3} isn't equals to OrPredicates(id3, OrPredicates(id1, id2))={idOr3}".format(**locals())
+                        ); nbAsserts+=1
+
+        if nbAsserts<=0: raise Warning("Any assertion in the test loop");
+         
 
 # End TestIntervalsDelay
 # ---------------------------------------------------------------------------

--- a/Packager/bin/tests_annotationdata_filter/test_delay_relations.py
+++ b/Packager/bin/tests_annotationdata_filter/test_delay_relations.py
@@ -496,15 +496,15 @@ class TestIntervalsDelay(unittest.TestCase):
                             pred = idc(pai, paj)
                             if (j-i) > Maxd:
                                 self.assertFalse(pred
-                                    , "IntervalsDelays[{xk},{yk},{mk},{Mk}]({pai}, {paj}) isn't false when ({j}-{i}) > {Maxd} (pred={pred}; ped.delay={pred_delay})".format(pred_delay=pred.delay if (hasattr(pred,'delay')) else None,**locals())
+                                        , "IntervalsDelays[{xk},{yk},{mk},{Mk}]({pai}, {paj}) isn't false when ({j}-{i}) > {Maxd} (pred={pred}; pred.delay={pred_delay}, idc.delay()={idc_delay:r})".format(pred_delay=pred.delay if (hasattr(pred,'delay')) else None, idc_delay=idc.delay(*IntervalsDelay.splitAnnotations(pai, paj)), **locals())
                                     ); nbAsserts+=1
                             elif (mind is None or mind<=(j-i)):
                                 self.assertTrue(pred
-                                    , "IntervalsDelays[{xk},{yk},{mk},{Mk}]({pai}, {paj}) isn't true when {mind} <= ({j}-{i}) < {Maxd} (pred={pred}; ped.delay={pred_delay})".format(pred_delay=pred.delay if (hasattr(pred,'delay')) else None,**locals())
+                                    , "IntervalsDelays[{xk},{yk},{mk},{Mk}]({pai}, {paj}) isn't true when {mind} <= ({j}-{i}) < {Maxd} (pred={pred}; pred.delay={pred_delay}, idc.delay()={idc_delay:r})".format(pred_delay=pred.delay if (hasattr(pred,'delay')) else None, idc_delay=idc.delay(*IntervalsDelay.splitAnnotations(pai, paj)), **locals())
                                     ); nbAsserts+=1
                             else: # (j-i) < min
                                 self.assertFalse(pred
-                                    , "IntervalsDelays[{xk},{yk},{mk},{Mk}]({pai}, {paj}) isn't false when ({j}-{i}) < {mind} (pred={pred}; ped.delay={pred_delay})".format(pred_delay=pred.delay if (hasattr(pred,'delay')) else None,**locals())
+                                    , "IntervalsDelays[{xk},{yk},{mk},{Mk}]({pai}, {paj}) isn't false when ({j}-{i}) < {mind} (pred={pred}; pred.delay={pred_delay}, idc.delay()={idc_delay:r})".format(pred_delay=pred.delay if (hasattr(pred,'delay')) else None, idc_delay=idc.delay(*IntervalsDelay.splitAnnotations(pai, paj)), **locals())
                                     ); nbAsserts+=1
                     # compare a point and an interval annotations
                     for start1 in self.pointAnnotations.keys():

--- a/sppas/src/annotationdata/filter/delay_relations.py
+++ b/sppas/src/annotationdata/filter/delay_relations.py
@@ -451,6 +451,7 @@ class Delay(object):
     def __add__(self, other):
         """
         Delay addition
+        (!) the new margin is the max of the initial margins
         @type other:    Delay or float/int
         @return:    a Delay with the sum of value and the maximum margin
         """
@@ -471,6 +472,7 @@ class Delay(object):
     def __sub__(self, other):
         """
         Delay substraction
+        (!) the new margin is the max of the initial margins
         @type other:    Delay or float/int
         @return:    a Delay with the difference of values and the maximum margin
         """
@@ -491,6 +493,7 @@ class Delay(object):
     def __mul__(self, other):
         """
         Delay multiplication
+        (!) the new margin is the max of the initial margins
         @type other:    Delay or float/int
         @return:    a Delay with the product of values and the maximum margin
         """
@@ -511,6 +514,7 @@ class Delay(object):
     def __div__(self, other):
         """
         Delay "classic" division
+        (!) the new margin is the max of the initial margins
         @type other:    Delay or float/int
         @return:    a Delay with the "classic" division of values and the maximum margin
         """
@@ -659,6 +663,7 @@ class IntervalsDelay(BinaryPredicate):
             delay = (yvalue - xvalue)
         else: # __DEFAULT_DIRECTION
             delay = (xvalue - yvalue) if self.__DEFAULT_DIRECTION=='after' else (yvalue - xvalue)
+        #print "delay({xstart}, {xend}, {ystart}, {yend})\n\t=> {xpoint}, {ypoint}\n\t=> ({xvalue}, {xmargin}) , ({yvalue}, {ymargin}) hasMargin:{hasMargin}\n\t{delay} (direction={self.direction})".format(**locals())
         return Delay(delay, xmargin+ymargin) if hasMargin else delay;
 
     def check(self, xstart, xend, ystart, yend):
@@ -816,6 +821,7 @@ class IntervalsDelay(BinaryPredicate):
         @return: the point corresponding to the percent of the interval
         @rtype: TimePoint (better) if start/end are a TimePoint, else a float
         """
+        if start is end:  return start; # point
         if percent==0.:  return start;
         if percent==1.:  return end;
         # compute the percent point

--- a/sppas/src/annotationdata/filter/delay_relations.py
+++ b/sppas/src/annotationdata/filter/delay_relations.py
@@ -435,8 +435,19 @@ class Delay(object):
 
     
     # -----------------------------------------------------------------------
-    # --- formating methods
+    # --- mathematic methods
     # -----------------------------------------------------------------------
+    def _newSelf(self, value, margin=None):
+        """
+        Method that try to build a new instance of 
+        """
+        #TODO: try a 'copy' of self
+        try:
+            return type(self)(value, margin)    # new object of the same class that self
+        #TODO: try all the inheritance path between self and Delay
+        except:
+            return Delay(value, margin)
+
     def __add__(self, other):
         """
         Delay addition
@@ -453,9 +464,9 @@ class Delay(object):
             if omargin <= smargin:
                 return self
             else:
-                return Delay(svalue, omargin)
+                return self._newSelf(svalue, omargin)
         margin = omargin if omargin > smargin else smargin
-        return Delay(svalue+ovalue, margin)
+        return self._newSelf(svalue+ovalue, margin)
 
     def __sub__(self, other):
         """
@@ -473,9 +484,9 @@ class Delay(object):
             if omargin <= smargin:
                 return self
             else:
-                return Delay(svalue, omargin)
+                return self._newSelf(svalue, omargin)
         margin = omargin if omargin > smargin else smargin
-        return Delay(svalue-ovalue, margin)
+        return self._newSelf(svalue-ovalue, margin)
 
     def __mul__(self, other):
         """
@@ -493,9 +504,9 @@ class Delay(object):
             if omargin <= smargin:
                 return self
             else:
-                return Delay(svalue, omargin)
+                return self._newSelf(svalue, omargin)
         margin = omargin if omargin > smargin else smargin
-        return Delay(svalue*ovalue, margin)
+        return self._newSelf(svalue*ovalue, margin)
 
     def __div__(self, other):
         """
@@ -515,9 +526,9 @@ class Delay(object):
             if omargin <= smargin:
                 return self
             else:
-                return Delay(svalue, omargin)
+                return self._newSelf(svalue, omargin)
         margin = omargin if omargin > smargin else smargin
-        return Delay(svalue/ovalue, margin)
+        return self._newSelf(svalue/ovalue, margin)
 
 
     def __truediv__(self, other):
@@ -538,12 +549,12 @@ class Delay(object):
             if omargin <= smargin:
                 return self
             else:
-                return Delay(svalue, omargin)
+                return self._newSelf(svalue, omargin)
         margin = omargin if omargin > smargin else smargin
-        return Delay(svalue/ovalue, margin)
+        return self._newSelf(svalue/ovalue, margin)
 
     def __neg__(self):
-        return Delay(-self.value, self.margin);
+        return self._newSelf(-self.value, self.margin);
 
     def __pos__(self):
         return self;

--- a/sppas/src/annotationdata/filter/delay_relations.py
+++ b/sppas/src/annotationdata/filter/delay_relations.py
@@ -1,0 +1,657 @@
+#!/usr/bin/env python2
+# vim: set fileencoding=UTF-8 ts=4 sw=4 expandtab:
+# ---------------------------------------------------------------------------
+#            ___   __    __    __    ___
+#           /     |  \  |  \  |  \  /              Automatic
+#           \__   |__/  |__/  |___| \__             Annotation
+#              \  |     |     |   |    \             of
+#           ___/  |     |     |   | ___/              Speech
+#
+#
+#                           http://www.sppas.org/
+#
+# ---------------------------------------------------------------------------
+#            Laboratoire Parole et Langage, Aix-en-Provence, France
+#                   Copyright (C) 2011-2016  Brigitte Bigi
+#
+#                   This banner notice must not be removed
+# ---------------------------------------------------------------------------
+# Use of this software is governed by the GNU Public License, version 3.
+#
+# SPPAS is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# SPPAS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with SPPAS. If not, see <http://www.gnu.org/licenses/>.
+#
+# ---------------------------------------------------------------------------
+# File: delay_relations.py
+# ----------------------------------------------------------------------------
+
+__docformat__ = """epytext"""
+__authors__   = """Tatsuya Watanabe, Brigitte Bigi (brigitte.bigi@gmail.com), Grégoire Montcheuil"""
+__copyright__ = """Copyright (C) 2011-2015  Brigitte Bigi"""
+
+#---------------------------------------------------------------
+# Utils
+#---------------------------------------------------------------
+
+
+def joinWithQuote(sep, *args, **kwargs):
+    if len(args)<=0: return "";
+    if 'lastsep' in kwargs:
+        return ( "'%s'" % args[0] if (len(args)<2)
+               else ( sep.join(map(lambda k: "'%s'" % k, args[:-2]))
+                    + kwargs['lastsep'] + ("'%s'" % args[:-1])
+                    )
+               )
+    else:
+        return sep.join(map(lambda k: "'%s'" % k, args))
+
+
+
+#---------------------------------------------------------------
+class JoinList(list):
+    """
+    A list with customizable str() method
+    @param args:    the list of predicates
+    @param kwargs:    options
+        - sep (str): set the join separator (default: ',')
+        - left (str): string before the list, p.e. '[' (default: '')
+        - right (str): string after the list, p.e. ']' (default: '')
+    """
+    def __init__(self, *args, **kwargs):
+        list.__init__(self, args)
+        self.__str__opts = {'sep':',', 'left':'', 'right':''}
+        for k,v in kwargs.items():
+            self.__str__opts[k]=v;
+
+    def __str__(self):
+        return "{left}{join}{right}".format(
+                left = self.__str__opts['left'] if (self.__str__opts['left'] is not None) else '',
+                right = self.__str__opts['right'] if (self.__str__opts['right'] is not None) else '',
+                join = (self.__str__opts['sep'] if (self.__str__opts['sep'] is not None) else '').join(map(str, self))
+                )
+
+#---------------------------------------------------------------
+class OrPredicates(JoinList):
+    """
+    A Predicates disjunction
+    @param args:    the list of predicates
+    @param kwargs:    options
+        - name : set a name for string conversion
+        if falsy, string conversion join the predicates' names with " OR "
+    """
+
+    def __init__(self, *args, **kwargs):
+        JoinList.__init__(self, *args, sep=" OR ", **kwargs)
+        self.name = kwargs.get('name', None)
+
+    def __call__(self, *args, **kwargs):
+        """
+        Call the sequence of predicate, returning the first truthy result (not None, False, 0, '', []).
+        @return: the first truthy result or None if any.
+        """
+        # return the 1st not None result
+        for p in self:
+            res = p(*args, **kwargs)
+            if res:
+                return res
+        return None # any not None result
+    
+    def __str__(self):
+        return self.name if (self.name is not None) else JoinList.__str__(self)
+
+#---------------------------------------------------------------
+class AndPredicates(JoinList):
+    """
+    A Predicates conjunction
+    @param args:    the list of predicates
+    @param kwargs:    options
+        - name : set a name for string conversion
+        if falsy, string conversion join the predicates' names with " AND "
+    """
+
+    def __init__(self, *args, **kwargs):
+        JoinList.__init__(self, *args, sep=" AND ", **kwargs)
+        self.name = kwargs.get('name', None)
+
+    def __call__(self, *args, **kwargs):
+        """
+        Call the sequence of predicate, returning the list of results or None if any result is falsy (None, False, 0, '', []).
+        @return: the list of all results if all are verified
+            or None if any result is falsy
+        """
+        results = JoinList(sep=" and ")
+        # return None if one is None
+        for p in self:
+            res = p(*args, **kwargs)
+            if res:
+                results.append(res)
+            else:
+                return None;
+        # join the result
+        return results #" AND ".join(map(str, results))
+
+    def __str__(self):
+        return self.name if (self.name is not None) else JoinList.__str__(self)
+
+
+#---------------------------------------------------------------
+# IntervalsDelay
+#---------------------------------------------------------------
+
+#---------------------------------------------------------------
+class BinaryPredicate(object):
+    """
+    A BinaryPredicate is an abstract Predicate with 2 Annotation parameters
+    So you should callesd instance with 2 Annotation parameters
+        bp = BinaryPredicate(...)
+        bp(x,y, **kwargs)
+    """
+    pass
+
+#---------------------------------------------------------------
+class IntervalsDelay(BinaryPredicate):
+    """
+    Predicate on the Maximal/minimal delay between two intervals.
+    The reference point of each interval is express in percent,
+     i.e. start point <=> 0%, end point <=> 100%, middle point 50% (default), etc.
+    """
+
+    # some points percent values
+    POINTS_PERCENT={'start':0, 'end':1, 'mid':0.5, 'middle':0.5}
+    # the default points percent values (middle)
+    DEFAULT_PERCENT=0.5
+    # 'percent' name
+    PERCENT_ALIASES=('percent', '%')
+    
+    def __init__(self, mindelay=0, maxdelay=0, xpercent=DEFAULT_PERCENT, ypercent=DEFAULT_PERCENT, name=''):
+        """
+        Build a new IntervalsDelay
+        @param mindelay:    minimum delay between the 2 intervals (in second, default:0)
+        @type mindelay: float
+        @param maxdelay:    maximum delay between the 2 intervals (in second, default:0)
+        @type maxdelay: float
+        @param xpercent:    first interval reference point ([0,1], default:0.5)
+        @type xpercent: float
+        @param ypercent:    second interval reference point ([0,1], default:0.5)
+        @type ypercent: float
+        @param name:    custom name for the relation
+        @type name: str
+        """
+        IntervalsDelay.validMinMaxDelay(mindelay, maxdelay) # raise ValueError
+        self.mindelay = mindelay
+        self.maxdelay = maxdelay
+        self.xpercent = xpercent
+        self.ypercent = ypercent
+        self.name = name
+
+    def delay(self, x1, x2, y1, y2):
+        """
+        Compute the actual delay between the two intervals
+        @param x1:  first interval start point
+        @param x2:  first interval end point
+        @param y1:  second interval start point
+        @param y2:  second interval end point
+        """
+        return ( ( (1-self.ypercent) * y1.GetMidpoint() + self.ypercent * y2.GetMidpoint() )
+               - ( (1-self.xpercent) * x1.GetMidpoint() + self.xpercent * x2.GetMidpoint() )
+               )
+
+    def check(self, x1, x2, y1, y2):
+        """
+        Check if the delay between the two intervals respect max/mindelay
+        @param x1:  first interval start point
+        @param x2:  first interval end point
+        @param y1:  second interval start point
+        @param y2:  second interval end point
+        """
+        delay = self.delay(x1, x2, y1, y2)
+        #print "[{self.xpercent},{self.ypercent}] delay({x1}, {x2}, {y1}, {y2}) = {delay}".format(**locals())
+        if IntervalsDelay.checkDelay(delay, self.mindelay, self.maxdelay):
+            return CheckedIntervalsDelay(delay, **{a:getattr(self,a) for a in ['mindelay', 'maxdelay', 'xpercent', 'ypercent']})
+        else:
+            return None;
+
+    def __call__(self, *args, **kwargs):
+        """
+        IntervalsDelay's predicate
+        Accecpt either:
+            - 2 Annotation arguments (x,y)
+            - 4 Point arguments (x1, x2, y1, y2)
+        """
+        if (len(args)==2): # 2 arguments => x,y (Annotation) => split into x1, x2, y1, y2
+            return self.check(*IntervalsDelay.splitAnnotations(*args))
+        elif (len(args)==4): # 4 arguments => yet x1, x2, y1, y2
+            return self.check(*args)
+        else:
+            raise ValueError("IntervalsDelay's function require 2 Annotation parameters or 4 Point parameters")
+
+    def __str__(self):
+        if self.name:
+            return self.name
+        else:
+            return '_'.join([IntervalsDelay.pointStr(self.xpercent), IntervalsDelay.pointStr(self.ypercent), IntervalsDelay.delayStr(self.mindelay, self.maxdelay)])
+
+    def __cmp__(self, other):
+        """
+        Compare IntervalsDelay based on 
+            - (1) the first interval point (i.e. xpercent)
+            - (2) the second interval point (i.e. ypercent)
+            - (3) the minimal delay (None ~ -infinity)
+            - (3) the maximal delay (None ~ +infinity)
+        """
+        def sign(x):
+            if x<0: return -1;
+            if x>0: return +1;
+            return 0;
+
+        res = self.xpercent - other.xpercent # start < mid < end
+        if res: return sign(res);
+        res = self.ypercent - other.ypercent # start < mid < end
+        if res: return sign(res);
+        # compare mindelay (None is -infinity)
+        if self.mindelay is None:
+            res = ( 0 if other.mindelay is None # both None => 'equals'
+                    else -1 ) # self(-infinity) < other
+        else:
+            res = ( +1 if other.mindelay is None # self > other(-infinity)
+                    else self.mindelay - other.mindelay ) # self - other
+        if res: return sign(res);
+        # compare maxdelay (None is +infinity)
+        if self.maxdelay is None:
+            res = ( 0 if other.maxdelay is None # both None => 'equals'
+                    else +1 ) # self(+infinity) > other
+        else:
+            res = ( -1 if other.maxdelay is None # self < other(+infinity)
+                    else self.maxdelay - other.maxdelay ) # self - other
+        return sign(res);
+
+    @staticmethod
+    def validMinMaxDelay(mindelay, maxdelay):
+        """
+        Check if the min/max delays are a valid combination,
+         i.e. min <= max, considering None as -/+infinity
+        """
+        if mindelay is None: # -infinity
+            if maxdelay is None:
+                raise ValueError("min/maxdelay can't be both None")
+            return True;
+        if maxdelay is None: # +infinity
+            return True; # mindelay != None
+        if mindelay > maxdelay: # min < max
+            raise ValueError("mindelay({}) should be less or equals to maxdelay({})".format(mindelay, maxdelay))
+        return True;
+
+    @staticmethod
+    def pointStr(percent):
+        """
+        Convert a percent to the point name (start/end/middle/<p>%)
+        """
+        if percent is None: return 'percent'; # default/undefined
+        try:
+            fpercent = float(percent)
+            if fpercent==0.: return 'start'
+            if fpercent==1.: return 'end'
+            if fpercent==0.5: return 'middle'
+            return "{:02.0%}".format(fpercent)
+        except:
+            raise ValueError("Percent value '{}' isn't a real number".format(percent))
+
+    @staticmethod
+    def delayStr(mindelay=0, maxdelay=0, unit='', delayformat='.3f'):
+        """
+        Convert the minimal/maximal delays into string
+        """
+        if maxdelay is None: # max is None => +infinity
+            if mindelay is None:
+                raise ValueError("[delayStr] at least one not None delay required")
+            elif mindelay < 0: # negative min => explicit [min, +infinity[
+                return ("between[{:"+delayformat+"}{unit},+infinity[").format(mindelay, unit=unit)
+            #?elif mindelay ==0: return "after"  
+            else: # positive min => implicit +infinity
+                return ("min({:"+delayformat+"}{unit})").format(mindelay, unit=unit)
+        elif mindelay is None: # min is None => -infinity
+            if maxdelay < 0: # negative max => implicit ]-infinity,max]
+                return ("max({:"+delayformat+"}{unit})").format(maxdelay, unit=unit)
+            #?elif maxdelay==0: return "before"
+            else:   # positive min => explicit ]-infinity,max]
+                return ("between]-infinity,{:"+delayformat+"}{unit}]").format(maxdelay, unit=unit)
+        else: # both defined
+            if (maxdelay<mindelay):
+                raise ValueError("[delayStr] maxdelay({:f}) should be greater or equal to mindelay({:f})".format(maxdelay,mindelay))
+            if (mindelay==maxdelay):
+                return ("equals({:"+delayformat+"}{unit})").format(maxdelay, unit=unit)
+            elif (mindelay==0): # [0,max] => implicit 0
+                return ("max({:"+delayformat+"}{unit})").format(maxdelay, unit=unit)
+            else:
+                return ("between[{:"+delayformat+"},{:"+delayformat+"}{unit}]").format(mindelay, maxdelay, unit=unit)
+
+    @staticmethod
+    def checkDelay(delay, mindelay=0, maxdelay=0):
+        """
+        Check a delay value between (optionals) maxdelay/mindelay
+        @param delay:   the delay
+        @type delay:    float
+        @param mindelay:    the minimum delay (if defined, default 0)
+        @type mindelay: float or None
+        @param maxdelay:    the maximum delay (if defined, default 0)
+        @type maxdelay: float or None
+        @rtype: Boolean
+        """
+        return (  (mindelay is None or delay >= mindelay)
+                and (maxdelay is None or delay <= maxdelay)
+                )
+    
+    # copy of annotationdata/filter/_relations.py#split()
+    @staticmethod
+    def splitAnnotations(x, y):
+        """ x,y (Annotation) """
+        if x.GetLocation().IsPoint():
+            x1 = x.GetLocation().GetPoint()
+            x2 = x.GetLocation().GetPoint()
+        else:
+            x1 = x.GetLocation().GetBegin()
+            x2 = x.GetLocation().GetEnd()
+        if y.GetLocation().IsPoint():
+            y1 = y.GetLocation().GetPoint()
+            y2 = y.GetLocation().GetPoint()
+        else:
+            y1 = y.GetLocation().GetBegin()
+            y2 = y.GetLocation().GetEnd()
+        return x1, x2, y1, y2
+
+    @staticmethod
+    def parsePoint(ptStr, default=DEFAULT_PERCENT, prefix=None):
+        """
+        Parse a point string into it's percent value
+        @type ptStr:    str
+        @param ptStr:    the point string (start, end, mid, 20%, ...)
+        @param type:  float, None
+        @param default:  (optional) the default value
+        @param type:  str
+        @param prefix:  (optional) a prefix for a return of type {xpercent=<value>}
+        @rtype: float or dict
+        @return:    the percent value, or a {<prefix>percent=<value>} object if prefix is defined
+        @raise ValueError:  uncorrect ptStr
+        """
+        percent=default
+        if ptStr in IntervalsDelay.POINTS_PERCENT: percent = IntervalsDelay.POINTS_PERCENT[ptStr];
+        elif ptStr in IntervalsDelay.PERCENT_ALIASES: pass;# percent => return DEFAULT_PERCENT
+        elif ptStr.endswith('%'):
+            try:
+                percent = float(ptStr[:-1]) / 100
+            except:
+                raise ValueError("Invalid percent value '%s'" % ptStr)
+        else: raise ValueError("Invalid point '%s', correct values are %s or %s or <p>%%" % (xpoint, joinWithQuote(", ", IntervalsDelay.POINTS_PERCENT.keys()), joinWithQuote("/", IntervalsDelay.PERCENT_ALIASES)));
+        return percent if not prefix else {prefix+"percent" : percent}
+
+    @staticmethod
+    def relationValues(rel, value, res=None):
+        """
+        Parse a point string into it's percent value
+        @type rel:    str
+        @param rel:    the 'relation' part : min, max, eq, ...
+        @type value:  float, (min, max), {delay=<float>}
+        @param value:  the 'numeric' value(s)
+        @type res:  a dict
+        @param res:  (optional) the result object
+        @return:    an dict with mindelay/maxdelay key:value set
+        @raise ValueError:  uncorrect relation/value(s)
+        """
+
+        def floatOrNone(v):
+            return None if v is None else float(v);
+
+        # init res
+        if res is None: res={};
+        
+        # Get the value(s)
+        v, vmin, vmax = None, None, None
+        # (a) using attributes delay or mindelay/maxdelay
+        if ( hasattr(value, 'mindelay') or hasattr(value, 'maxdelay') ):
+            vmin = floatOrNone(value.mindelay) if hasattr(value, 'mindelay') else None;
+            vmax = floatOrNone(value.maxdelay) if hasattr(value, 'maxdelay') else None;
+        elif hasattr(value, 'delay'):
+            v = floatOrNone(value.delay); # raise ValueError for invalid number
+        # (b) 'dict' using key delay or mindelay/maxdelay
+        elif isinstance(value, dict) and ( 'mindelay' in value or 'maxdelay' in value ):
+            vmin = floatOrNone(value.get('mindelay', None));
+            vmax = floatOrNone(value.get('maxdelay', None));
+        elif isinstance(value, dict) and 'delay' in value:
+            v = floatOrNone(value['delay']); # raise ValueError for invalid number
+        # (c) list/tuple of one (delay), two(min/max) (or more value)
+        elif isinstance(value, (list, tuple)) and not isinstance(value, basestring):
+            if len(value)>1:  vmin = floatOrNone(value[0]); vmax = floatOrNone(value[1]);
+            elif len(value)>0: v = floatOrNone(value[0]);
+            else: raise ValueError("Empty value(s) tuple")
+        # (d) one (float) value
+        else: v = floatOrNone(value);
+        #HERE: we have v or (vmin,vmax) set and others are None
+
+        # Check the relation
+        if isinstance(rel, str):
+            if len(rel)==0: # empty str
+                if v is not None: # only one value => equivalent to 'eq'
+                    res['maxdelay'] = v; # v
+                    res['mindelay'] = v; # v
+                else:   # min and max values
+                    res['maxdelay'] = vmax; # vmax
+                    res['mindelay'] = vmin; # vmin
+            elif rel.startswith('min'):
+                res['mindelay'] = vmin if vmin is not None else v; # vmin or v
+                res['maxdelay'] = 0 if (res['mindelay'] is None or res['mindelay']<0) else None; # max is +∞ (or 0 if min is negative)
+            elif rel.startswith('max'): # max or empty str
+                res['maxdelay'] = vmax if vmax is not None else v; # vmax or v
+                res['mindelay'] = 0 if (res['maxdelay'] is None or res['maxdelay'] >= 0) else None; # min is 0 (or -∞ if max is negative)
+            elif rel.startswith('eq'):
+                res['maxdelay'] = v if v is not None else vmax; # v or vmax
+                res['mindelay'] = res['maxdelay'];
+            else: raise ValueError("relation '%s' isn't a valid relation, correct values are 'max', 'min' or 'eq'" % rel);
+        else:
+            raise ValueError("relation '%s' isn't a valid relation, correct values are 'max', 'min' or 'eq'" % rel);
+        return res;
+    
+    
+    #---------------------------------------------------------------
+    # Predicate factory function
+    #---------------------------------------------------------------
+    @staticmethod
+    def create(*args, **kwargs):
+        """
+        Create a IntervalsDelay predicate.
+        For complex predicate, the default is a conjunction ('and').
+        Can be specified by a first parameter or the special key 'join'
+        @param args: a key-value sequence
+            keys have generally the form <point>_<point>(_<rel>)?
+                where <point> are in 'start', 'end', 'mid'/'middle' or 'percent' (default)
+                  and <rel> are 'max' (default), 'min' or 'eq'
+            values are either a single numeric value (for maxdelay and/or mindelay),
+                          or a dict of parameters (p.e. {maxdelay=1, xpercent=0.3} after 'percent_start')
+            Special keys :
+            - name(str): the relation name
+            - join(str): 'and' or 'or' 
+        @param kwargs: more key-value, same as args
+        """
+        # the default options
+        DEFAULT_OPTS={'maxdelay':0, 'mindelay':0, 'xpercent':0.5, 'ypercent':0.5}
+        JOIN_VALUES=('and', 'or');
+        atts = {'join':'and'}; # relation attributes
+        
+        #----- convert (key, value) into options
+        def keyValueOptions(k,v):
+            # (0) special keys
+            # (0.1) the 'join' attribute
+            if k.lower() == 'join':
+                if v.lower() in JOIN_VALUES:
+                    atts['join'] = v.lower()
+                    #print("[keyValueOptions({k},{v})]Set 'join' attribute to {join}".format(join=atts['join'], **locals()))
+                else:
+                    raise ValueError("Bad join value '%s', correct values are %s" % (v, joinWithQuote(", ", *JOIN_VALUES, lastsep=" or ")));
+                return None;
+            # (0.2) the 'name' attribute
+            if k.lower() == 'name':
+                atts['name'] = v
+                return None;
+    
+            # build the final options
+            opts = v.copy() if isinstance(v, dict) else {};
+    
+            # (a) split key into <point>_<point>(_<rel>)?
+            xpoint, ypoint, rel = 3 * [None]
+            ksplit = k.lower().split('_', 2);
+            if len(ksplit)<2:
+                raise ValueError("Bad point_point value '%s'" % k);
+            else:
+                xpoint=ksplit[0]; ypoint=ksplit[1];
+            if len(ksplit)>2: rel=ksplit[2];
+            
+            # (b) set xpercent/ypercent
+            # xpoint => update xpercent
+            xpercent = IntervalsDelay.parsePoint(xpoint, opts.get('xpercent')) # raise ValueError
+            if xpercent is not None: opts['xpercent'] = xpercent;
+            #?  else:   opts['xpercent'] = DEFAULT_OPTS['xpercent'];
+            # ypoint => update xpercent
+            ypercent = IntervalsDelay.parsePoint(ypoint, opts.get('ypercent')) # raise ValueError
+            if ypercent is not None: opts['ypercent'] = ypercent;
+            #?  else:   opts['ypercent'] = DEFAULT_OPTS['ypercent'];
+            
+            # (c) set mindelay/maxdelay
+            # rel (and numeric value or v.delay) => update min/maxdelay
+            if not rel: rel=''; # remplace falsy value of rel by the empty string
+            IntervalsDelay.relationValues(rel, v, opts); # set mindelay/maxdelay in opts, raise ValueError
+            if 'delay' in opts: del opts['delay']; # remove 'delay', now convert into mindelay/maxdelay
+            return opts;
+            
+        #-----
+    
+        # look for the first argument
+        iArg=0;
+        if len(args)>0 and (args[iArg].lower() in JOIN_VALUES):
+            atts['join'] = args[iArg].lower(); iArg+=1  # the join type
+        
+        lOpts = []
+        # other arguments
+        while iArg < len(args):
+            k = args[iArg]; iArg+=1
+            v = DEFAULT_OPTS;
+            if iArg<len(args):
+                v = args[iArg]; iArg+=1
+            opts = keyValueOptions(k,v)
+            if opts: lOpts.append(opts);
+        # and the kwargs
+        for k, v in kwargs.items():
+            opts = keyValueOptions(k,v)
+            if opts: lOpts.append(opts);
+    
+        # create IntervalsDelay for each lOpts and join them
+        lIntDelays = map(lambda opts: IntervalsDelay(**opts), lOpts)
+    
+        #TODO: reduce AND predicates with the same (xpercent,ypercent)
+        # b.e. (start_start_max=2, start_start_min=1)
+        #   => {xpercent=0,ypercent=0, maxdelay=2, mindelay=0} AND {xpercent=0,ypercent=0, maxdelay=None, mindelay=1}
+        #  --> {xpercent=0,ypercent=0, maxdelay=2, mindelay=1}
+
+        if len(lIntDelays)==1:
+            if atts.get('name') is not None:
+                lIntDelays[0].name = atts['name']
+            return lIntDelays[0]
+        elif atts['join']=='or':
+            #print "[create({args}, {kwargs})] => OrPredicates({lIntDelaysStr},{atts})".format(lIntDelaysStr=[str(item) for item in lIntDelays] ,**locals())
+            return OrPredicates(*lIntDelays, **atts)
+        else:
+            return AndPredicates(*lIntDelays, **atts)
+    
+    
+#---------------------------------------------------------------
+class CheckedIntervalsDelay(IntervalsDelay):
+    def __init__(self, delay, mindelay=0, maxdelay=0, xpercent=IntervalsDelay.DEFAULT_PERCENT, ypercent=IntervalsDelay.DEFAULT_PERCENT, name=''):
+        IntervalsDelay.__init__(self, mindelay=mindelay, maxdelay=maxdelay, xpercent=xpercent, ypercent=ypercent, name=name)
+        self.delay=delay;
+
+    def delay(self):
+        """
+        Get the actual delay.
+        """
+        return  self.delay
+
+
+#---------------------------------------------------------------
+
+def start_start(x1, x2, y1, y2, mindelay=0, maxdelay=0):
+    """
+    Maximal/minimal delay between 2 intervals starts
+      |----x----|
+          |---y---|
+      |~d~|          mindelay <= d <= maxdelay
+    """
+    return IntervalsDelay(mindelay, maxdelay, xpercent=0, ypercent=0).check(x1, x2, y1, y2)
+
+def start_end(x1, x2, y1, y2, mindelay=0, maxdelay=0):
+    """
+    Maximal/minimal delay between first interval start and second interval end
+      |----x----|
+          |---y---|
+      |~~~~~d~~~~~|  mindelay <= d <= maxdelay
+    """
+    return IntervalsDelay(mindelay, maxdelay, xpercent=0, ypercent=1).check(x1, x2, y1, y2)
+
+def end_start(x1, x2, y1, y2, mindelay=0, maxdelay=0):
+    """
+    Maximal/minimal delay between first interval end and second interval start
+      |-x-|
+            |-y-|
+          |d|        mindelay <= d <= maxdelay
+    """
+    return IntervalsDelay(mindelay, maxdelay, xpercent=1, ypercent=0).check(x1, x2, y1, y2)
+
+def end_end(x1, x2, y1, y2, mindelay=0, maxdelay=0):
+    """
+    Maximal/minimal delay between 2 intervals ends
+      |----x----|
+          |---y---|
+                |d|  mindelay <= d <= maxdelay
+    """
+    return IntervalsDelay(mindelay, maxdelay, xpercent=1, ypercent=1).check(x1, x2, y1, y2)
+
+def percent_start(x1, x2, y1, y2, mindelay=0, maxdelay=0, xpercent=0.5):
+    """
+    Maximal/minimal delay between a fraction of the first interval and the start of the second interval
+       |-+--x----|    where the '+' mark xpercent of the interval x
+           |---y---|
+         |d|          mindelay <= d  <= maxdelay
+     nota: startStartDelay <=> percentStartDelay(xpercent=0), endStartDelay <=> percentStartDelay(xpercent=1)
+    """
+    return IntervalsDelay(mindelay, maxdelay, xpercent, ypercent=0).check(x1, x2, y1, y2)
+
+
+def percent_end(x1, x2, y1, y2, mindelay=0, maxdelay=0, xpercent=0.5):
+    """
+    Maximal/minimal delay between a fraction of the first interval and the end of the second interval
+       |-+--x----|    where the '+' mark xpercent of the interval x
+           |---y---|
+         |~~~~d~~~~|  mindelay <= d
+     nota: startEndDelay <=> percentEndDelay(xpercent=0), endEndDelay <=> percentEndDelay(xpercent=1), 
+    """
+    return IntervalsDelay(mindelay, maxdelay, xpercent, ypercent=1).check(x1, x2, y1, y2)
+
+
+def percent_percent(x1, x2, y1, y2, mindelay=0, maxdelay=0, xpercent=0.5, ypercent=0.5):
+    """
+    Maximal/minimal delay between a fraction of the first interval and a fraction of the second interval
+       |-+--x----|    where the '+' mark xpercent of the interval x
+           |---y+--|  where the '+' mark ypercent of the interval y
+         |~~~d~~|     mindelay <= d
+     nota: startStartDelay <=> percentPercentDelay(xpercent=0, ypercent=0), endStartDelay <=> percentPercentDelay(xpercent=1, ypercent=0), 
+     nota: startEndDelay <=> percentPercentDelay(xpercent=0, ypercent=1), endEndDelay <=> percentPercentDelay(xpercent=1, ypercent=1), 
+    """
+    return IntervalsDelay(mindelay, maxdelay, xpercent, ypercent).check(x1, x2, y1, y2)
+

--- a/sppas/src/annotationdata/filter/delay_relations.py
+++ b/sppas/src/annotationdata/filter/delay_relations.py
@@ -113,6 +113,25 @@ class OrPredicates(JoinList):
     
     def __str__(self):
         return self.name if (self.name is not None) else JoinList.__str__(self)
+    
+    #---------------------------------------------
+    #-- '&' and '|' operators
+    #---------------------------------------------
+
+    #---------------------------------------------
+    def __or__(self, other):
+        """
+        Allow to combine 2 predicates with the '|' operator
+        """
+        return OrPredicates(self, other)
+
+    #---------------------------------------------
+    def __and__(self, other):
+        """
+        Allow to combine 2 predicates with the '&' operator
+        """
+        return AndPredicates(self, other)
+
 
 #---------------------------------------------------------------
 class AndPredicates(JoinList):
@@ -148,6 +167,25 @@ class AndPredicates(JoinList):
     def __str__(self):
         return self.name if (self.name is not None) else JoinList.__str__(self)
 
+    #---------------------------------------------
+    #-- '&' and '|' operators
+    #---------------------------------------------
+
+    #---------------------------------------------
+    def __or__(self, other):
+        """
+        Allow to combine 2 predicates with the '|' operator
+        """
+        return OrPredicates(self, other)
+
+    #---------------------------------------------
+    def __and__(self, other):
+        """
+        Allow to combine 2 predicates with the '&' operator
+        """
+        return AndPredicates(self, other)
+
+    #TODO?  def __invert__(self):
 
 #---------------------------------------------------------------
 # Delay : a value with a margin/vagueness/radius
@@ -668,6 +706,26 @@ class IntervalsDelay(BinaryPredicate):
                     else self.maxdelay - other.maxdelay ) # self - other
         return sign(res);
 
+    
+    #---------------------------------------------
+    #-- '&' and '|' operators
+    #---------------------------------------------
+
+    #---------------------------------------------
+    def __or__(self, other):
+        """
+        Allow to combine 2 predicates with the '|' operator
+        """
+        return OrPredicates(self, other)
+
+    #---------------------------------------------
+    def __and__(self, other):
+        """
+        Allow to combine 2 predicates with the '&' operator
+        """
+        return AndPredicates(self, other)
+
+    #---------------------------------------------
     @staticmethod
     def validMinMaxDelay(mindelay, maxdelay):
         """


### PR DESCRIPTION
As as said you, `annotationdata/filter/delay_relations.py` contains
 - the class **IntervalsDelay** that allow:
   - calculate delay between 2 'arbitrary' points of the intervals (start/end/middle/percent)
   - work like a predicate and filter intervals based on a min/max delay
   - define the expected 'direction' between X and Y ('before' => (delay>0 <=> X before Y) / 'after' => (delay>0 <=> X after Y))
   - deal with the TimePoint's radius
   - a create() method to build new IntervalsDelay (combination) in an 'easier' way (or not?)
 - 2 tool classes **OrPredicates/AndPredicates** to easily combine predicates
 - the class **Delay** similar to Duration but allowing negative values and adding some facilities (change the 'numeric' class between float/Decimal, 'unpack' TimePoint, Duration, etc.

In `Packager`
  - `bin/tests_annotationdata_filter/test_delay.py` : a few unit tests for the Delay class
  - `bin/tests_annotationdata_filter/test_delay_relations.py` : various unit tests for IntervalsDelay