### PR TITLE
Elan better

### DIFF
--- a/sppas/src/annotationdata/aio/elan.py
+++ b/sppas/src/annotationdata/aio/elan.py
@@ -125,14 +125,14 @@ class Elan( Transcription ):
 
         # manage hierarchyLinks
         for parentTierRef in self.hierarchyLinks:
-            child = self.hierarchyLinks[parentTierRef]
-            parent = self.Find(parentTierRef)
-            # Elan's hierarchy
-            try:
-                self._hierarchy.add_link('TimeAlignment', child, parent)
-            except:
-                # TODO: to send a warning
-                pass
+            for child in self.hierarchyLinks[parentTierRef]:  # a parent tier could have various children
+                parent = self.Find(parentTierRef)
+                # Elan's hierarchy
+                try:
+                    self._hierarchy.add_link('TimeAlignment', child, parent)
+                except:
+                    # TODO: to send a warning
+                    pass
 
         del self.hierarchyLinks
         del self.unit
@@ -239,7 +239,9 @@ class Elan( Transcription ):
 
     def __read_ref_tier(self, tier, tierRoot, parentTierRef, root):
         # add a link to process later
-        self.hierarchyLinks[parentTierRef] = tier
+        if parentTierRef not in self.hierarchyLinks:
+            self.hierarchyLinks[parentTierRef] = []
+        self.hierarchyLinks[parentTierRef].append(tier)
 
         # group annotations in batches
         batches = {}

--- a/sppas/src/annotationdata/aio/elan.py
+++ b/sppas/src/annotationdata/aio/elan.py
@@ -338,6 +338,7 @@ class Elan( Transcription ):
 
     def __read_time_slots(self, timeOrderRoot):
         timeSlotCouples = []
+        # read the <TIME_SLOT> element
         for timeSlotNode in timeOrderRoot.findall('TIME_SLOT'):
             id = timeSlotNode.attrib['TIME_SLOT_ID']
 
@@ -349,18 +350,19 @@ class Elan( Transcription ):
 
             timeSlotCouples.append((id, value))
 
-            for i in range(1, len(timeSlotCouples)-1):
+        # create a midpoint value for undefined TIME_VALUE
+        for i in range(1, len(timeSlotCouples)-1):
+            (id, val) = timeSlotCouples[i]
+            if val is None:
                 (prevId, prevVal) = timeSlotCouples[i-1]
-                (id, val) = timeSlotCouples[i]
                 (nextId, nextVal) = timeSlotCouples[i+1]
-                if val is None:
-                    midPoint = (prevVal.GetMidpoint() +
-                                nextVal.GetMidpoint()) / 2
-                    newVal = TimePoint(midPoint, midPoint -
-                                       prevVal.GetMidpoint())
-                    timeSlotCouples[i] = (id, newVal)
+                midPoint = (prevVal.GetMidpoint() +
+                            nextVal.GetMidpoint()) / 2 # /!\ failed if nextVal is None
+                newVal = TimePoint(midPoint, midPoint -
+                                   prevVal.GetMidpoint())
+                timeSlotCouples[i] = (id, newVal)
 
-            self.timeSlots = dict(timeSlotCouples)
+        self.timeSlots = dict(timeSlotCouples)
 
     # -----------------------------------------------------------------
     # Writer


### PR DESCRIPTION
Review of the code to read ELAN files.

(a) Read faster :
 - [692e9fd] fix an embeded loop in __read_time_slots
 - [8b04b22] and [e3a1d78] use an index to speed up the search of reference annotations

(b) Various tiers with the same parent reference
[2c23d2a] before only the last tier keep the hierarchy link to its parent, now the whole list of children is kept.