### PR TITLE
Elan : BUG writting TimePoint tier(s)

### DIFF
--- a/sppas/src/annotationdata/aio/annotationpro.py
+++ b/sppas/src/annotationdata/aio/annotationpro.py
@@ -38,14 +38,14 @@
 import xml.etree.cElementTree as ET
 import datetime
 
-from sppas.src.annotationdata.transcription import Transcription
-from sppas.src.annotationdata.label.label import Label
-from sppas.src.annotationdata.ptime.location import Location
-import sppas.src.annotationdata.ptime.point
-from sppas.src.annotationdata.ptime.interval import TimeInterval
-from sppas.src.annotationdata.ptime.localization import Localization
-from sppas.src.annotationdata.annotation import Annotation
-from sppas.src.annotationdata.media import Media
+from ..transcription import Transcription
+from ..label.label import Label
+from ..ptime.location import Location
+from ..ptime.point import TimePoint as pTimePoint
+from ..ptime.interval import TimeInterval
+from ..ptime.localization import Localization
+from ..annotation import Annotation
+from ..media import Media
 
 from utils import indent
 from utils import gen_id
@@ -127,7 +127,7 @@ UpperLowerDict['projectnoises'] = "ProjectNoises"
 
 
 def TimePoint(time):
-    return sppas.src.annotationdata.ptime.point.TimePoint(time, ANTX_RADIUS)
+    return pTimePoint(time, ANTX_RADIUS)
 
 # ---------------------------------------------------------------------------
 

--- a/sppas/src/annotationdata/aio/elan.py
+++ b/sppas/src/annotationdata/aio/elan.py
@@ -48,13 +48,13 @@ import datetime
 import xml.etree.cElementTree as ET
 from collections import OrderedDict
 
-from sppas.src.annotationdata.transcription  import Transcription
-from sppas.src.annotationdata.ctrlvocab      import CtrlVocab
-from sppas.src.annotationdata.media          import Media
-from sppas.src.annotationdata.label.label    import Label
-import sppas.src.annotationdata.ptime.point
-from sppas.src.annotationdata.ptime.interval import TimeInterval
-from sppas.src.annotationdata.annotation     import Annotation
+from ..transcription  import Transcription
+from ..ctrlvocab      import CtrlVocab
+from ..media          import Media
+from ..label.label    import Label
+from ..ptime.point    import TimePoint as pTimePoint
+from ..ptime.interval import TimeInterval
+from ..annotation     import Annotation
 
 from utils import indent
 from utils import gen_id
@@ -74,7 +74,7 @@ ELAN_RADIUS = 0.02
 # -----------------------------------------------------------------
 
 def TimePoint(time, radius=ELAN_RADIUS):
-    return sppas.src.annotationdata.ptime.point.TimePoint(time, radius)
+    return pTimePoint(time, radius)
 
 def linguistic_type_from_tier(tier):
     return (tier.metadata['LINGUISTIC_TYPE_REF']

--- a/sppas/src/annotationdata/aio/phonedit.py
+++ b/sppas/src/annotationdata/aio/phonedit.py
@@ -39,11 +39,11 @@ import codecs
 from datetime import datetime
 import re
 
-from sppas.src.annotationdata.transcription import Transcription
-from sppas.src.annotationdata.annotation import Annotation
-from sppas.src.annotationdata.label.label import Label
-from sppas.src.annotationdata.ptime.interval import TimeInterval
-import sppas.src.annotationdata.ptime.point
+from ..transcription import Transcription
+from ..annotation import Annotation
+from ..label.label import Label
+from ..ptime.interval import TimeInterval
+from ..ptime.point import TimePoint as pTimePoint
 
 # ----------------------------------------------------------------------------
 
@@ -53,7 +53,7 @@ PHONEDIT_RADIUS = 0.0005
 
 
 def TimePoint(time):
-    return sppas.src.annotationdata.ptime.point.TimePoint(time, PHONEDIT_RADIUS)
+    return pTimePoint(time, PHONEDIT_RADIUS)
 
 # ----------------------------------------------------------------------------
 

--- a/sppas/src/annotationdata/aio/utils.py
+++ b/sppas/src/annotationdata/aio/utils.py
@@ -309,16 +309,18 @@ def merge_overlapping_annotations(tier, separator=' '):
 # ------------------------------------------------------------------------
 
 
-def point2interval(tier, fixradius=None):
+def point2interval(tier, fixradius=None, minradius=0.001):
     """
     Convert localization.
-    Ensure the radius to be always >= 1 millisecond.
+    Ensure the radius to be always >= minradius (1 millisecond).
 
     Do not convert alternatives.
 
     (!) Result interval annotations share the metadata of the original point annotation
 
     @param tier: (Tier)
+    @param fixradius: the radius to use for all interval (if not None, else the point radius)
+    @param minradius: a minimal radius
     @return Tier
 
     """
@@ -338,8 +340,8 @@ def point2interval(tier, fixradius=None):
         point = a.GetLocation().GetPoint()
         midpoint = point.GetMidpoint()
         radius = fixradius if fixradius is not None else point.GetRadius()
-        if radius < 0.001:
-            radius = 0.001
+        if radius < minradius:
+            radius = minradius
 
         begin = TimePoint(midpoint-radius,radius)
         end   = TimePoint(midpoint+radius,radius)


### PR DESCRIPTION
The commit 4858dee solve the KeyError thrown by ```__format_alignable_annotation()``` method when writing a ELAN file with timepoint tier(s).
The problem was due to ```self.timeSlotIds``` keys that contains copy of original annotations and so have a different hash signature.


